### PR TITLE
Add data-test* attributes with field uri to components

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-selector/edit.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector/edit.hbs
@@ -20,7 +20,7 @@
           @loadingMessage="Aan het laden..."
           @noMatchesMessage="Geen resultaten gevonden"
           as |concept|>
-    {{concept.label}}
+          <span data-test-field-uri={{concept.subject.value}}> {{concept.label}} </span>
   </PowerSelect>
 </div>
 

--- a/addon/components/rdf-input-fields/concept-scheme-selector/edit.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector/edit.hbs
@@ -6,6 +6,9 @@
 </AuLabel>
 <div class="{{if this.errors "ember-power-select--error"}}">
   <PowerSelect
+          data-test-field-uri={{@field.uri}}
+          @tagName="div"
+          @renderInPlace="true"
           @triggerId={{this.inputId}}
           @searchField={{"label"}}
           @searchEnabled={{this.searchEnabled}}

--- a/addon/components/rdf-input-fields/date-time/edit.hbs
+++ b/addon/components/rdf-input-fields/date-time/edit.hbs
@@ -8,7 +8,8 @@
   <div class="au-o-grid__item au-u-2-4">
     <div class="au-c-date-picker-container {{if this.errors "au-c-date-picker-container--error"}}">
       <div class="datepicker">
-      <WuDatepickerInput
+      <WuDatepickerInput 
+              data-test-field-uri={{@field.uri}}
               id="{{this.inputId}}"
               class="au-c-input au-c-input--block"
               @dateFormat="DD.MM.YYYY"

--- a/addon/components/rdf-input-fields/files/edit.hbs
+++ b/addon/components/rdf-input-fields/files/edit.hbs
@@ -9,7 +9,7 @@
 {{#each this.files as |fileField|}}
   <VoMuFileCard @file={{fileField.record}} @onDelete={{this.removeFile}}/>
 {{/each}}
-<VoMuFileDropzone id="{{this.inputId}}" role="button" @onFinishUpload={{this.addFile}} @maxFileSizeMB="1024" class="{{if this.errors "upload--error"}}"/>
+<VoMuFileDropzone data-test-field-uri={{@field.uri}} id="{{this.inputId}}" role="button" @onFinishUpload={{this.addFile}} @maxFileSizeMB="1024" class="{{if this.errors "upload--error"}}"/>
 
 
 {{#each this.errors as |error|}}


### PR DESCRIPTION
**Components**
- WuDatepickerInput 
- VoMuFileDropzone
- PowerSelect

**Note**
For Power select there is not an immediate "clean" way of adding the uri's to the list options. Momentarily just added a wrapper span to it where I add the data-test attribute. PowerSelect has a  `optionsComponent` that lets you use a component to replace the default `li` but that seems excessive and not sure if you can pass attributes and properties to it.

I though of maybe doing something like

```hbs
{{#if production}}
    {{concept.label}}
{{else}}
    <span data-test-field-uri={{concept.subject.value}}> {{concept.label}} </span>
{{/if}}
```

But do not really know if this is possible, maybe with a helper instead? But apart from this it seems inevitable of creating another component or extra wrapper for this case 
