### PR TITLE
Remove wrong click handler

### DIFF
--- a/addon/components/rdf-input-fields/date-range/show.hbs
+++ b/addon/components/rdf-input-fields/date-range/show.hbs
@@ -1,9 +1,9 @@
 <div class="js-accordion js-accordion--open">
   <AuLabel>{{@field.label}}</AuLabel>
   <AuButtonGroup @inline="true">
-    <AuButton {{ on "click" null }}
+    <AuButton
         class="{{if (not this.isEnabled) "is-active" }}" @skin="secondary" @disabled="true">Alle meldingen</AuButton>
-    <AuButton {{ on "click" null }}
+    <AuButton
         class="{{if this.isEnabled "is-active" }}" @skin="secondary" @disabled="true">Specifieke periode</AuButton>
   </AuButtonGroup>
 


### PR DESCRIPTION
No need for {{on 'click' null}. Suffices to just not define a click handler. Fixes https://github.com/lblod/frontend-toezicht-abb/pull/8#issuecomment-758661087 reset error