### PR TITLE
Add usage of a defaultValue param in some inputs

### DIFF
--- a/addon/components/rdf-input-fields/checkbox/edit.js
+++ b/addon/components/rdf-input-fields/checkbox/edit.js
@@ -4,6 +4,8 @@ import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 
+// Note : default values are not working yet with this component, loadProvidedValue is overriden
+
 export default class RdfInputFieldsCheckboxEditComponent extends SimpleInputFieldComponent {
   inputId = 'checkbox-' + guidFor(this);
 
@@ -11,7 +13,7 @@ export default class RdfInputFieldsCheckboxEditComponent extends SimpleInputFiel
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
-      this.value = matches.values[0].value === "1";
+      this.value = matches.values[0].value === "1"; // There is a bug in conversion from rdflib
     }
   }
 

--- a/addon/components/rdf-input-fields/input-field.js
+++ b/addon/components/rdf-input-fields/input-field.js
@@ -65,6 +65,10 @@ export default class InputFieldComponent extends Component {
     return this.remainingCharacters >= 0;
   }
 
+  get defaultValue() {
+    return this.args.field.defaultValue;
+  }
+
   get storeOptions() {
     return {
       formGraph: this.args.graphs.formGraph,

--- a/addon/components/rdf-input-fields/input/edit.hbs
+++ b/addon/components/rdf-input-fields/input/edit.hbs
@@ -7,6 +7,7 @@
     <AuPill @skin={{unless this.hasRemainingCharacters "error"}} >Resterende karakters: {{this.remainingCharacters}}</AuPill>
   {{/if}}
 </AuLabel>
+
 <AuInput
         class="{{if this.errors "au-c-input--error"}}"
         id="{{this.inputId}}"

--- a/addon/components/rdf-input-fields/input/edit.js
+++ b/addon/components/rdf-input-fields/input/edit.js
@@ -1,13 +1,52 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
+import { FORM, SHACL } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
 
 export default class FormInputFieldsInputEditComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
 
+  constructor() {
+    super(...arguments);
+
+    if (!this.value) {
+      this.setDefaultValue();
+      next(this, () => {
+        if (this.value) {
+          this.updateFieldValue();
+        }
+      });
+    }
+  }
+
   @action
   updateValue(e) {
     e.preventDefault();
+    this.updateFieldValue();
+  }
+
+  updateFieldValue() {
     super.updateValue(this.value && this.value.trim());
+  }
+
+  /**
+   * Sets a default value on the field if the property `form:defaultValue` is defined in the
+   * field's configuration
+   */
+  setDefaultValue() {
+    const field = this.storeOptions.store.match(
+      undefined,
+      SHACL('path'),
+      this.storeOptions.path,
+      this.storeOptions.formGraph)[0].subject;
+
+    const defaultValueTriple = this.storeOptions.store.match(
+      field,
+      FORM('defaultValue'),
+      undefined,
+      this.storeOptions.formGraph)[0];
+
+    if (defaultValueTriple) this.value = defaultValueTriple.object.value;
   }
 }

--- a/addon/components/rdf-input-fields/input/edit.js
+++ b/addon/components/rdf-input-fields/input/edit.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
-import { FORM, SHACL } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
 
 export default class FormInputFieldsInputEditComponent extends SimpleInputFieldComponent {
@@ -10,12 +9,10 @@ export default class FormInputFieldsInputEditComponent extends SimpleInputFieldC
   constructor() {
     super(...arguments);
 
-    if (!this.value) {
-      this.setDefaultValue();
+    if (!this.value && this.defaultValue) {
+      this.value = this.defaultValue;
       next(this, () => {
-        if (this.value) {
-          this.updateFieldValue();
-        }
+        this.updateFieldValue();
       });
     }
   }
@@ -28,25 +25,5 @@ export default class FormInputFieldsInputEditComponent extends SimpleInputFieldC
 
   updateFieldValue() {
     super.updateValue(this.value && this.value.trim());
-  }
-
-  /**
-   * Sets a default value on the field if the property `form:defaultValue` is defined in the
-   * field's configuration
-   */
-  setDefaultValue() {
-    const field = this.storeOptions.store.match(
-      undefined,
-      SHACL('path'),
-      this.storeOptions.path,
-      this.storeOptions.formGraph)[0].subject;
-
-    const defaultValueTriple = this.storeOptions.store.match(
-      field,
-      FORM('defaultValue'),
-      undefined,
-      this.storeOptions.formGraph)[0];
-
-    if (defaultValueTriple) this.value = defaultValueTriple.object.value;
   }
 }

--- a/addon/components/rdf-input-fields/input/edit.js
+++ b/addon/components/rdf-input-fields/input/edit.js
@@ -1,29 +1,14 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
-import { next } from '@ember/runloop';
 
 export default class FormInputFieldsInputEditComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
 
-  constructor() {
-    super(...arguments);
-
-    if (!this.value && this.defaultValue) {
-      this.value = this.defaultValue;
-      next(this, () => {
-        this.updateFieldValue();
-      });
-    }
-  }
-
   @action
   updateValue(e) {
-    e.preventDefault();
-    this.updateFieldValue();
-  }
-
-  updateFieldValue() {
+    if (e && typeof e.preventDefault === "function")
+      e.preventDefault();
     super.updateValue(this.value && this.value.trim());
   }
 }

--- a/addon/components/rdf-input-fields/numerical-input/edit.js
+++ b/addon/components/rdf-input-fields/numerical-input/edit.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
 import rdflib from 'browser-rdflib';
-import { XSD, FORM, SHACL } from '@lblod/submission-form-helpers';
+import { XSD } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
 
 export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInputFieldComponent {
@@ -11,12 +11,10 @@ export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInp
   constructor() {
     super(...arguments);
 
-    if (!this.value) {
-      this.setDefaultValue();
+    if (!this.value && this.defaultValue) {
+      this.value = this.defaultValue;
       next(this, () => {
-        if (this.value) {
-          this.updateFieldValue();
-        }
+        this.updateFieldValue();
       });
     }
   }
@@ -43,25 +41,5 @@ export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInp
     }
     // NOTE: everything that is not a number is a string.
     return XSD('string');
-  }
-
-  /**
-   * Sets a default value on the field if the property `form:defaultValue` is defined in the
-   * field's configuration
-   */
-  setDefaultValue() {
-    const field = this.storeOptions.store.match(
-      undefined,
-      SHACL('path'),
-      this.storeOptions.path,
-      this.storeOptions.formGraph)[0].subject;
-
-    const defaultValueTriple = this.storeOptions.store.match(
-      field,
-      FORM('defaultValue'),
-      undefined,
-      this.storeOptions.formGraph)[0];
-
-    if (defaultValueTriple) this.value = defaultValueTriple.object.value;
   }
 }

--- a/addon/components/rdf-input-fields/numerical-input/edit.js
+++ b/addon/components/rdf-input-fields/numerical-input/edit.js
@@ -2,14 +2,32 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
 import rdflib from 'browser-rdflib';
-import { XSD } from '@lblod/submission-form-helpers';
+import { XSD, FORM, SHACL } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
 
 export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
 
+  constructor() {
+    super(...arguments);
+
+    if (!this.value) {
+      this.setDefaultValue();
+      next(this, () => {
+        if (this.value) {
+          this.updateFieldValue();
+        }
+      });
+    }
+  }
+
   @action
   updateValue(e) {
     e.preventDefault();
+    this.updateFieldValue();
+  }
+
+  updateFieldValue() {
     const number = rdflib.literal(Number(this.value), this.datatype);
     super.updateValue(number);
   }
@@ -25,5 +43,25 @@ export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInp
     }
     // NOTE: everything that is not a number is a string.
     return XSD('string');
+  }
+
+  /**
+   * Sets a default value on the field if the property `form:defaultValue` is defined in the
+   * field's configuration
+   */
+  setDefaultValue() {
+    const field = this.storeOptions.store.match(
+      undefined,
+      SHACL('path'),
+      this.storeOptions.path,
+      this.storeOptions.formGraph)[0].subject;
+
+    const defaultValueTriple = this.storeOptions.store.match(
+      field,
+      FORM('defaultValue'),
+      undefined,
+      this.storeOptions.formGraph)[0];
+
+    if (defaultValueTriple) this.value = defaultValueTriple.object.value;
   }
 }

--- a/addon/components/rdf-input-fields/numerical-input/edit.js
+++ b/addon/components/rdf-input-fields/numerical-input/edit.js
@@ -3,29 +3,14 @@ import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
 import rdflib from 'browser-rdflib';
 import { XSD } from '@lblod/submission-form-helpers';
-import { next } from '@ember/runloop';
 
 export default class RdfInputFieldsNumericalInputEditComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
 
-  constructor() {
-    super(...arguments);
-
-    if (!this.value && this.defaultValue) {
-      this.value = this.defaultValue;
-      next(this, () => {
-        this.updateFieldValue();
-      });
-    }
-  }
-
   @action
   updateValue(e) {
-    e.preventDefault();
-    this.updateFieldValue();
-  }
-
-  updateFieldValue() {
+    if (e && typeof e.preventDefault === "function")
+      e.preventDefault();
     const number = rdflib.literal(Number(this.value), this.datatype);
     super.updateValue(number);
   }

--- a/addon/components/rdf-input-fields/simple-value-input-field.js
+++ b/addon/components/rdf-input-fields/simple-value-input-field.js
@@ -2,6 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from './input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { updateSimpleFormValue } from '@lblod/submission-form-helpers';
+import { next } from '@ember/runloop';
 
 export default class SimpleValueInputFieldComponent extends InputFieldComponent {
   @tracked value = null
@@ -17,6 +18,11 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
       this.value = matches.values[0].value;
+    } else if (this.defaultValue && this.value == null) {
+      this.value = this.defaultValue;
+      next(this, () => {
+        this.updateValue();
+      });
     }
   }
 

--- a/addon/components/rdf-input-fields/switch/edit.js
+++ b/addon/components/rdf-input-fields/switch/edit.js
@@ -4,6 +4,8 @@ import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../simple-value-input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 
+// Note : default values are not working yet with this component, loadProvidedValue is overriden
+
 export default class FormInputFieldsSwitchEditComponent extends SimpleInputFieldComponent {
   inputId = 'switch-' + guidFor(this);
 

--- a/addon/components/rdf-input-fields/text-area/edit.js
+++ b/addon/components/rdf-input-fields/text-area/edit.js
@@ -7,7 +7,8 @@ export default class FormInputFieldsTextAreaEditComponent extends SimpleInputFie
 
   @action
   updateValue(e) {
-    e.preventDefault();
+    if (e && typeof e.preventDefault === "function")
+      e.preventDefault();
     super.updateValue(this.value && this.value.trim());
   }
 }

--- a/addon/models/field.js
+++ b/addon/models/field.js
@@ -19,6 +19,7 @@ export default class FieldModel {
     this.rdflibDisplayType = store.any( uri, FORM("displayType"), undefined, formGraph );
     this.rdflibPath = store.any( uri, SHACL("path"), undefined, formGraph );
     this.rdflibOptions = store.any( uri, FORM("options"), undefined, formGraph );
+    this.rdflibDefaultValue = store.any( uri, FORM('defaultValue'), undefined, formGraph );
     if(this.rdflibPath) {
       // this.rdflibValue = store.any(sourceNode, this.rdflibPath, undefined, sourceGraph);
     }
@@ -64,5 +65,11 @@ export default class FieldModel {
   rdflibOptions = null;
   get options(){
     return this.rdflibOptions && this.rdflibOptions.value;
+  }
+
+  @tracked
+  rdflibOptions = null;
+  get defaultValue() {
+    return this.rdflibDefaultValue && this.rdflibDefaultValue.value;
   }
 }

--- a/addon/models/field.js
+++ b/addon/models/field.js
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 
-import { SHACL, FORM, validationTypesForField } from '@lblod/submission-form-helpers';
+import { SHACL, FORM } from '@lblod/submission-form-helpers';
 
 export default class FieldModel {
 


### PR DESCRIPTION
This PR initializes the `defaultInput` and `numericalInput` with a default value when a `form:defaultValue` is configured as such : 

```
fields:e19e245a-c24b-4fb5-84b8-a7e2744ce9a1 a form:Field ;
    mu:uuid "e19e245a-c24b-4fb5-84b8-a7e2744ce9a1";
    sh:name "Test default value" ;
    sh:order 10 ;
    sh:path schema:testInput ;
    form:displayType displayTypes:defaultInput ;
    form:defaultValue "I'm a default input :)" ;
    sh:group fields:2232cd10-01d6-4f67-966a-2c22932437b4 .
```