### PR TITLE
Don't render form fields without a displayType

### DIFF
--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -20,39 +20,41 @@
     {{/if}}
     {{!-- NOTE: Children can be property-groups as well as fields --}}
     {{#each this.children as |child index|}}
-      {{#unless (is-property-group child.displayType)}}
-        <div class="au-u-margin-bottom-small">
-          {{component (component-for-display-type child.displayType show=@show)
-                      field=child
-                      form=@form
-                      formStore=@formStore
-                      graphs=@graphs
-                      sourceNode=@sourceNode
-                      forceShowErrors=@forceShowErrors
-                      cacheConditionals=@cacheConditionals
-                      show=@show
-          }}
-          <AuHelpText class="au-u-margin-none">{{child.help}}</AuHelpText>
-        </div>
-      {{else}}
-        <PropertyGroup
-                @level={{add this.level 1}}
-                @form={{@form}}
-                @group={{child}}
-                @formStore={{@formStore}}
-                @graphs={{@graphs}}
-                @sourceNode={{@sourceNode}}
-                @forceShowErrors={{@forceShowErrors}}
-                @cacheConditionals={{@cacheConditionals}}
-                @show={{@show}}/>
-        {{#if @last}}
-          {{#unless (eq index (sub this.children.length 1))}}
+      {{#if child.displayType}}
+        {{#if (is-property-group child.displayType)}}
+          <PropertyGroup
+                  @level={{add this.level 1}}
+                  @form={{@form}}
+                  @group={{child}}
+                  @formStore={{@formStore}}
+                  @graphs={{@graphs}}
+                  @sourceNode={{@sourceNode}}
+                  @forceShowErrors={{@forceShowErrors}}
+                  @cacheConditionals={{@cacheConditionals}}
+                  @show={{@show}}/>
+          {{#if @last}}
+            {{#if (not-eq index (sub this.children.length 1))}}
+              <AuHr @size="large"/>
+            {{/if }}
+          {{else}}
             <AuHr @size="large"/>
-          {{/unless }}
+          {{/if }}
         {{else}}
-          <AuHr @size="large"/>
-        {{/if }}
-      {{/unless}}
+          <div class="au-u-margin-bottom-small">
+            {{component (component-for-display-type child.displayType show=@show)
+                        field=child
+                        form=@form
+                        formStore=@formStore
+                        graphs=@graphs
+                        sourceNode=@sourceNode
+                        forceShowErrors=@forceShowErrors
+                        cacheConditionals=@cacheConditionals
+                        show=@show
+            }}
+            <AuHelpText class="au-u-margin-none">{{child.help}}</AuHelpText>
+          </div>
+        {{/if}}
+      {{/if}}
     {{/each}}
   </div>
 {{/if}}

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -9,25 +9,27 @@
   <ul class="au-o-grid au-o-grid--small">
 
     {{#each this.fields as |field|}}
-      <li class="au-o-grid__item au-u-1-1">
-        {{#if @show}}
-          {{component (component-for-display-type-show field.displayType)
-              field=field
-              formStore=@formStore
-              graphs=@graphs
-              sourceNode=@sourceNode}}
-        {{else}}
-          {{component
-              (component-for-display-type-edit field.displayType)
-              field=field
-              formStore=@formStore
-              graphs=@graphs
-              sourceNode=@sourceNode
-              forceShowErrors=@forceShowErrors
-          }}
-          <AuHelpText class="au-u-margin-none">{{{field.help}}}</AuHelpText>
-        {{/if}}
-      </li>
+      {{#if field.displayType}}
+        <li class="au-o-grid__item au-u-1-1">
+            {{#if @show}}
+              {{component (component-for-display-type-show field.displayType)
+                  field=field
+                  formStore=@formStore
+                  graphs=@graphs
+                  sourceNode=@sourceNode}}
+            {{else}}
+              {{component
+                  (component-for-display-type-edit field.displayType)
+                  field=field
+                  formStore=@formStore
+                  graphs=@graphs
+                  sourceNode=@sourceNode
+                  forceShowErrors=@forceShowErrors
+              }}
+              <AuHelpText class="au-u-margin-none">{{{field.help}}}</AuHelpText>
+            {{/if}}
+        </li>
+      {{/if}}
     {{/each}}
   </ul>
 </div>

--- a/addon/helpers/component-for-display-type-edit.js
+++ b/addon/helpers/component-for-display-type-edit.js
@@ -1,6 +1,7 @@
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
-export default helper(function componentForDisplayTypeEdit(displayTypeUri) {
+export default helper(function componentForDisplayTypeEdit([displayTypeUri]) {
   const mapping = {
     'http://lblod.data.gift/display-types/property-group' : 'property-group',
     'http://lblod.data.gift/display-types/defaultInput': `rdf-input-fields/input/edit`,
@@ -31,5 +32,10 @@ export default helper(function componentForDisplayTypeEdit(displayTypeUri) {
     'http://lblod.data.gift/display-types/objectiveTable': `custom-subsidy-form-fields/objective-table/edit`
   };
 
-  return mapping[displayTypeUri] || '';
+  assert(
+    `"${displayTypeUri}" did not resolve to a component name. Make sure the mapping exists or it doesn't contain any typos.`,
+    mapping[displayTypeUri]
+  );
+
+  return mapping[displayTypeUri];
 });

--- a/addon/helpers/component-for-display-type-show.js
+++ b/addon/helpers/component-for-display-type-show.js
@@ -1,6 +1,7 @@
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
-export default helper(function componentForDisplayTypeShow(displayTypeUri) {
+export default helper(function componentForDisplayTypeShow([displayTypeUri]) {
   const mapping = {
     'http://lblod.data.gift/display-types/property-group' : 'property-group',
     'http://lblod.data.gift/display-types/defaultInput': `rdf-input-fields/input/show`,
@@ -31,5 +32,10 @@ export default helper(function componentForDisplayTypeShow(displayTypeUri) {
     'http://lblod.data.gift/display-types/objectiveTable': `custom-subsidy-form-fields/objective-table/show`
   };
 
-  return mapping[displayTypeUri] || '';
+  assert(
+    `"${displayTypeUri}" did not resolve to a component name. Make sure the mapping exists or it doesn't contain any typos.`,
+    mapping[displayTypeUri]
+  );
+
+  return mapping[displayTypeUri];
 });

--- a/addon/helpers/component-for-display-type.js
+++ b/addon/helpers/component-for-display-type.js
@@ -1,4 +1,6 @@
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
+
 const mapping = {
   edit : {
     'http://lblod.data.gift/display-types/defaultInput': `rdf-input-fields/input/edit`,
@@ -54,10 +56,16 @@ const mapping = {
     'http://lblod.data.gift/display-types/engagementTable': `custom-subsidy-form-fields/engagement-table/show`,
     'http://lblod.data.gift/display-types/conceptSchemeMultiSelectCheckboxes': `rdf-input-fields/concept-scheme-multi-select-checkboxes/show`
   }
-}
+};
 
 export default helper(function componentForDisplayType([displayType], {show}) {
   let components = mapping.edit;
   if(show) components = mapping.show;
-  return components[displayType] || '';
+
+  assert(
+    `"${displayType}" did not resolve to a component name. Make sure the mapping exists or it doesn't contain any typos.`,
+    components[displayType]
+  );
+
+  return components[displayType];
 });


### PR DESCRIPTION
Some forms contain fields which are used for validation but don't need to be rendered.

I also added asserts that shows an error when a mapping isn't found. It might be easier to track missing mappings that way.

And I fixed some linting errors that I encountered.

Fixes the errors from #20 