### PR TITLE
Fix input tooltip error message when using decimals

### DIFF
--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.hbs
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.hbs
@@ -33,7 +33,7 @@
           <AuLabel for="costs-{{index}}" class="au-u-hidden-visually">
             Kosten (Excl. BTW)
           </AuLabel>
-          <AuInput id="costs-{{index}}" @width="block" @value={{entry.cost.value}}
+          <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}}
             type="number"
             class={{if entry.cost.errors "au-c-input--error"}}
             {{on "blur" (fn this.updateCost entry)}}
@@ -46,7 +46,7 @@
           <AuLabel for="share-{{index}}" class="au-u-hidden-visually">
             Het gemeentelijk aandeel (%) in kosten
           </AuLabel>
-          <AuInput id="share-{{index}}" @width="block" @value={{entry.share.value}}
+          <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}}
             type="number"
             class={{if entry.share.errors "au-c-input--error"}}
             {{on "blur" (fn this.updateShare entry)}}

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
@@ -28,7 +28,7 @@
           <AuLabel for="costs-{{index}}" class="au-u-hidden-visually">
             Kosten (Excl. BTW)
           </AuLabel>
-          <AuInput id="costs-{{index}}" @width="block" @value={{entry.cost.value}} disabled={{true}}
+          <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}} disabled={{true}}
             type="number"
           />
         </td>
@@ -36,7 +36,7 @@
           <AuLabel for="share-{{index}}" class="au-u-hidden-visually">
             Het gemeentelijk aandeel (%) in kosten
           </AuLabel>
-          <AuInput id="share-{{index}}" @width="block" @value={{entry.share.value}} disabled={{true}}
+          <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}} disabled={{true}}
             type="number"
           />
         </td>

--- a/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
+++ b/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
@@ -5,6 +5,7 @@
     lang="nl-BE"
     @width="block"
     @value={{this.kilometers}}
+    step="any"
     class={{if this.errors "au-c-input--error"}}
     {{on "blur" this.update}}
   />


### PR DESCRIPTION
- DL-2691
- fixes tooltip error message after sending form and hovering over the disabled input field. Happens in chrome
Why not use steps="0.01"? Well this causes the validation to stop working properly on some browsers. In Firefox for the objectives table for example if you use the arrow up and down button and choose 0.03 then the message that "at least one input field needs to have a value greater then 0" will still show. Why ? I dunno 

This is a quick fix but there are still inconsistencies in decimal numbers that will have to be looked at separately  