### PR TITLE
Auto focus on input when rendered

### DIFF
--- a/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
+++ b/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
@@ -10,6 +10,7 @@
     <tr>
       <td>
         <AuInput
+                {{auto-focus}}
                 id="{{this.inputId}}-{{index}}"
                 class="{{if remoteUrl.isInvalid "au-c-input--error"}}"
                 placeholder="http://www.uw-bestuur.be/specifiek-document"


### PR DESCRIPTION
Very small change that auto focuses input field whenever it renders. This can be when the user clicks on the 'Voeg nieuwe link toe' button