### PR TITLE
Fix/empty tables | climate & objectives table

### DIFF
--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/edit.js
@@ -2,7 +2,7 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import { next } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
@@ -53,10 +53,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableEditComponen
     super(...arguments);
     this.loadProvidedValue();
 
-    // Create table and entries in the store if not already existing
-    next(this, () => {
-      this.initializeTable();
-    });
+    scheduleOnce("actions", this, this.initializeTable);
   }
 
   loadProvidedValue() {

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import rdflib from 'browser-rdflib';
-import { next } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '@lblod/submission-form-helpers';
 
@@ -64,17 +64,18 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowBurg
 
   constructor() {
     super(...arguments);
-    //next for technical reasons
-    next(this, () => {
-      if (this.hasValues()) {
-        this.loadProvidedValue();
-        this.args.updateTotalRestitution(this.restitution);
-        this.onUpdateRow();
-      }
-      else {
-        this.initializeDefault();
-      }
-    });
+    scheduleOnce("actions", this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    }
+    else {
+      this.initializeDefault();
+    }
   }
 
   hasValues() {

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
@@ -3,7 +3,7 @@ import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { next } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 
 import { RDF, XSD } from '@lblod/submission-form-helpers';
 
@@ -64,17 +64,18 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowVast
 
   constructor() {
     super(...arguments);
-   //next for technical reasons
-    next(this, () => {
-      if (this.hasValues()) {
-        this.loadProvidedValue();
-        this.args.updateTotalRestitution(this.restitution);
-        this.onUpdateRow();
-      }
-      else {
-        this.initializeDefault();
-      }
-    });
+    scheduleOnce("actions", this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    }
+    else {
+      this.initializeDefault();
+    }
   }
 
   hasValues() {

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.js
@@ -3,7 +3,7 @@ import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { next } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 
 import { RDF, XSD } from '@lblod/submission-form-helpers';
 
@@ -51,17 +51,18 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowWerf
 
   constructor() {
     super(...arguments);
-   //next for technical reasons
-    next(this, () => {
-      if (this.hasValues()) {
-        this.loadProvidedValue();
-        this.args.updateTotalRestitution(this.restitution);
-        this.onUpdateRow();
-      }
-      else {
-        this.initializeDefault();
-      }
-    });
+    scheduleOnce("actions", this, this.initializeTableRow);
+  }
+
+  initializeTableRow() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
+      this.args.updateTotalRestitution(this.restitution);
+      this.onUpdateRow();
+    }
+    else {
+      this.initializeDefault();
+    }
   }
 
   hasValues() {

--- a/addon/components/custom-subsidy-form-fields/objective-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/objective-table/edit.js
@@ -5,7 +5,7 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
-import { next } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 
 const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
 
@@ -31,16 +31,18 @@ export default class CustomSubsidyFormFieldsObjectiveTableEditComponent extends 
 
   constructor() {
     super(...arguments);
+    scheduleOnce("actions", this, this.initTable );
+  }
+
+  initTable() {
     // Create table and entries in the store if not already existing
-    next(this, () => {
-      if(this.hasObjectiveTable){
-        this.loadProvidedValue();
-        this.validate();
-      }
-      else {
-        this.createObjectiveTable();
-      }
-    });
+    if(this.hasObjectiveTable){
+      this.loadProvidedValue();
+      this.validate();
+    }
+    else {
+      this.createObjectiveTable();
+    }
   }
 
   loadProvidedValue() {

--- a/addon/components/custom-subsidy-form-fields/objective-table/table-cell.js
+++ b/addon/components/custom-subsidy-form-fields/objective-table/table-cell.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { next } from '@ember/runloop';
+import { schedule } from '@ember/runloop';
 import rdflib from 'browser-rdflib';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -55,20 +55,21 @@ export default class CustomSubsidyFormFieldsObjectiveTableTableCellComponent ext
 
   constructor() {
     super(...arguments);
-    //next for technical reasons
-    next(this, () => {
-      if (this.hasValues()) {
-        this.loadProvidedValue();
-      }
-      else {
-        this.initializeDefault();
-      }
+    schedule("actions", this, this.initTableCell);
+  }
 
-      if(!this.args.disabled){
-        this.onUpdateCell();
-      }
+  initTableCell() {
+    if (this.hasValues()) {
+      this.loadProvidedValue();
 
-    });
+    }
+    else {
+      this.initializeDefault();
+    }
+
+    if(!this.args.disabled){
+      this.onUpdateCell();
+    }
   }
 
   hasValues() {


### PR DESCRIPTION
Instead of using next() creating inconsistencies and only calculating values after render we now use scheduleOnce and move the function call to be executed in the current runloop in the very first queue (actions queue). 

This also removes all warnings in console about re-computing