### PR TITLE
Add a basic test app setup

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,12 @@
 
 module.exports = {
   singleQuote: true,
+  overrides: [
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };

--- a/addon/components/rdf-input-fields/input-field.js
+++ b/addon/components/rdf-input-fields/input-field.js
@@ -48,7 +48,7 @@ export default class InputFieldComponent extends Component {
       this.args.field.uri,
       this.storeOptions
     );
-    return validationTypes.any(
+    return validationTypes.some(
       (v) =>
         v.value ===
         'http://lblod.data.gift/vocabularies/forms/RequiredConstraint'

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -1,4 +1,5 @@
 import InputFieldComponent from '../input-field';
+import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import {
@@ -49,7 +50,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     return this.inputId;
   }
 
-  @tracked remoteUrls = [];
+  @tracked remoteUrls = A();
 
   observerLabel = `remote-urls-${guidFor(this)}`; // Could have used uuidv4, but more consistent accross components
 

--- a/tests/dummy/app/components/test-form.hbs
+++ b/tests/dummy/app/components/test-form.hbs
@@ -1,0 +1,13 @@
+{{#if this.loadFormData.isRunning}}
+  <AuLoader @padding="small" />
+{{else}}
+  <RdfForm
+    @groupClass="au-o-grid__item"
+    @form={{this.form}}
+    @graphs={{this.graphs}}
+    @sourceNode={{this.sourceNode}}
+    @formStore={{this.formStore}}
+    @show={{false}}
+    @forceShowErrors={{false}}
+  />
+{{/if}}

--- a/tests/dummy/app/components/test-form.js
+++ b/tests/dummy/app/components/test-form.js
@@ -1,0 +1,73 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import rdflib from 'browser-rdflib';
+import { task } from 'ember-concurrency';
+
+const FORM_GRAPHS = {
+  formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
+  metaGraph: new rdflib.NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`),
+};
+
+const SOURCE_NODE = new rdflib.NamedNode(
+  'http://ember-submission-form-fields/source-node'
+);
+
+const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
+const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+
+export default class TestFormComponent extends Component {
+  @tracked form;
+  @tracked formStore;
+  graphs = FORM_GRAPHS;
+  sourceNode = SOURCE_NODE;
+
+  constructor() {
+    super(...arguments);
+
+    this.loadFormData.perform();
+  }
+
+  @task
+  *loadFormData() {
+    let formName = this.args.name;
+
+    let [formTtl, metaTtl] = yield Promise.all([
+      fetchForm(formName),
+      fetchFormMeta(formName),
+    ]);
+
+    let formStore = new ForkingStore();
+    formStore.parse(formTtl, FORM_GRAPHS.formGraph, 'text/turtle');
+    formStore.parse(metaTtl, FORM_GRAPHS.metaGraph, 'text/turtle');
+
+    let form = formStore.any(
+      undefined,
+      RDF('type'),
+      FORM('Form'),
+      FORM_GRAPHS.formGraph
+    );
+
+    this.form = form;
+    this.formStore = formStore;
+  }
+}
+
+async function fetchForm(formName) {
+  let response = await fetch(getFormDataPath(formName, 'form.ttl'));
+  let ttl = await response.text();
+
+  return ttl;
+}
+
+async function fetchFormMeta(formName) {
+  let response = await fetch(getFormDataPath(formName, 'meta.ttl'));
+  let ttl = await response.text();
+
+  return ttl;
+}
+
+function getFormDataPath(formName, fileName) {
+  return `/test-forms/${formName}/${fileName}`;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,27 @@
-{{page-title "Dummy"}}
+{{page-title "Dynamic form fields"}}
 
-<h2 id="title">Welcome to Ember</h2>
-
-{{outlet}}
+<AuApp>
+  <AuMainHeader @homeRoute="index" @appTitle="Dynamic form fields" />
+  <AuMainContainer as |m|>
+    <m.sidebar>
+      <div class="au-c-sidebar">
+        <div class="au-c-sidebar__content">
+          <nav>
+            <ul class="au-c-list-navigation">
+              <li class="au-c-list-navigation__item">
+                <AuNavigationLink @route="index">
+                  Basic form fields
+                </AuNavigationLink>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </m.sidebar>
+    <m.content @scroll={{true}}>
+      <div class="au-o-box au-o-box--large au-u-2-3@medium au-u-1-1">
+        {{outlet}}
+      </div>
+    </m.content>
+  </AuMainContainer>
+</AuApp>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,3 @@
+{{page-title "Basic fields"}}
+
+<TestForm @name="basic-fields" />

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -1,0 +1,225 @@
+# This form was generated using the form builder: https://poc-form-builder.relance.s.redpencil.io/formbuilder/6213B0B3B1D7CA00090000E2/edit
+
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+##########################################################
+# form
+##########################################################
+fieldGroups:main a form:FieldGroup ;
+    mu:uuid "70eebdf0-14dc-47f7-85df-e1cfd41c3855" .
+
+form:6b70a6f0-cce2-4afe-81f5-5911f45b0b27 a form:Form ;
+    mu:uuid "6b70a6f0-cce2-4afe-81f5-5911f45b0b27" ;
+    form:hasFieldGroup fieldGroups:main .
+
+##########################################################
+#  property-group
+##########################################################
+fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 a form:PropertyGroup;
+    mu:uuid "8e24d707-0e29-45b5-9bbf-a39e4fdb2c11";
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:name "Overview of all basic form fields" ;
+    sh:order 1 .
+
+##########################################################
+# Checkbox
+##########################################################
+fields:5cf93775-37b3-4e38-8b00-c1690949dbd5 a form:Field ;
+    mu:uuid "5cf93775-37b3-4e38-8b00-c1690949dbd5";
+    sh:name "Checkbox" ;
+    sh:order 190 ;
+    sh:path ext:732e98da-2ea5-4414-9094-82af73717c27 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:checkbox ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:5cf93775-37b3-4e38-8b00-c1690949dbd5 .
+
+##########################################################
+# Switch
+##########################################################
+fields:f5aad1e9-41c6-48ec-aa45-b881098ec4e5 a form:Field ;
+    mu:uuid "f5aad1e9-41c6-48ec-aa45-b881098ec4e5";
+    sh:name "Switch" ;
+    sh:order 191 ;
+    sh:path ext:58cee24d-840f-4de4-9baf-8fb2499c5bda ;
+    form:options """{}""" ;
+    form:displayType displayTypes:switch ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:f5aad1e9-41c6-48ec-aa45-b881098ec4e5 .
+
+##########################################################
+# Radio buttons
+##########################################################
+fields:48cad714-6ba0-4900-b5c3-f85879a7f580 a form:Field ;
+    mu:uuid "48cad714-6ba0-4900-b5c3-f85879a7f580";
+    sh:name "Radio buttons" ;
+    sh:order 210 ;
+    sh:path ext:ffa9c18b-eb5d-43fc-9126-cc89cc2647ef ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:48cad714-6ba0-4900-b5c3-f85879a7f580 .
+
+##########################################################
+# Input
+##########################################################
+fields:43dd5003-c9a4-48c6-b650-b90f2bce8c7d a form:Field ;
+    mu:uuid "43dd5003-c9a4-48c6-b650-b90f2bce8c7d";
+    sh:name "Simple input" ;
+    sh:order 220 ;
+    sh:path ext:b805ac8a-86dc-4a3e-aecd-81d2bcd46fc9 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:defaultInput ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:43dd5003-c9a4-48c6-b650-b90f2bce8c7d .
+
+##########################################################
+# Numerical input
+##########################################################
+fields:e3c282b1-d177-462e-9270-b2ce294b7457 a form:Field ;
+    mu:uuid "e3c282b1-d177-462e-9270-b2ce294b7457";
+    sh:name "Numerical input" ;
+    sh:order 221 ;
+    sh:path ext:1b7146d1-d3ac-41db-9c4e-ba6f757750e1 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:numericalInput ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:e3c282b1-d177-462e-9270-b2ce294b7457 .
+
+##########################################################
+# Text area
+##########################################################
+fields:c0bc308a-17c6-4ce4-a92e-a29cb8df93ca a form:Field ;
+    mu:uuid "c0bc308a-17c6-4ce4-a92e-a29cb8df93ca";
+    sh:name "Text area" ;
+    sh:order 230 ;
+    sh:path ext:47420052-2cc1-4e13-a62e-8d67b9c19493 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:c0bc308a-17c6-4ce4-a92e-a29cb8df93ca .
+
+##########################################################
+# Date
+##########################################################
+fields:aa63b985-d33f-4a2e-81df-accf8730e5ee a form:Field ;
+    mu:uuid "aa63b985-d33f-4a2e-81df-accf8730e5ee";
+    sh:name "Datepicker" ;
+    sh:order 240 ;
+    sh:path ext:8625f921-a345-4b7e-9e0d-1d88283ebc4f ;
+    form:options """{}""" ;
+    form:displayType displayTypes:date ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:aa63b985-d33f-4a2e-81df-accf8730e5ee .
+
+##########################################################
+# Date and time
+##########################################################
+fields:fe1f44c6-c69b-4171-affe-2f7e19288c8d a form:Field ;
+    mu:uuid "fe1f44c6-c69b-4171-affe-2f7e19288c8d";
+    sh:name "Date and time picker" ;
+    sh:order 250 ;
+    sh:path ext:20123484-23c5-4502-aa92-4bbdefc382c0 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:dateTime ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:fe1f44c6-c69b-4171-affe-2f7e19288c8d .
+
+##########################################################
+# Date range
+##########################################################
+fields:2c585f1e-6e77-4179-b36f-fba73d943491 a form:Field ;
+    mu:uuid "2c585f1e-6e77-4179-b36f-fba73d943491";
+    sh:name "Date range" ;
+    sh:order 260 ;
+    sh:path ext:0901577d-ea94-4b49-82fc-8186ca124af3 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:dateRange ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:2c585f1e-6e77-4179-b36f-fba73d943491 .
+
+##########################################################
+# Dropdown
+##########################################################
+fields:fd40cdcf-d085-4b71-930f-0b1c05e021d9 a form:Field ;
+    mu:uuid "fd40cdcf-d085-4b71-930f-0b1c05e021d9";
+    sh:name "Select" ;
+    sh:order 270 ;
+    sh:path ext:5cf85d01-a4d2-46a2-810f-130012881936 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:fd40cdcf-d085-4b71-930f-0b1c05e021d9 .
+
+##########################################################
+# Multi selector
+##########################################################
+fields:797b6eb4-537b-4f6a-88c3-8c5421c589ab a form:Field ;
+    mu:uuid "797b6eb4-537b-4f6a-88c3-8c5421c589ab";
+    sh:name "Multiselect" ;
+    sh:order 280 ;
+    sh:path ext:f93ed635-b580-4218-a11d-bb065860f744 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeMultiSelector ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:797b6eb4-537b-4f6a-88c3-8c5421c589ab .
+
+
+##########################################################
+# Urls
+##########################################################
+fields:3fb43220-0cf2-441e-9d7c-c2e10b67c537 a form:Field ;
+    mu:uuid "3fb43220-0cf2-441e-9d7c-c2e10b67c537";
+    sh:name "Url selector" ;
+    sh:order 310 ;
+    sh:path ext:756ca950-f35b-46c5-ab3d-fd99886e91f7 ;
+    form:options """{}""" ;
+    form:displayType displayTypes:remoteUrls ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:3fb43220-0cf2-441e-9d7c-c2e10b67c537 .
+
+##########################################################
+# Files
+##########################################################
+fields:8bdb4749-74cd-4299-91a2-abbf47c33474 a form:Field ;
+    mu:uuid "8bdb4749-74cd-4299-91a2-abbf47c33474";
+    sh:name "File uploader" ;
+    sh:order 320 ;
+    sh:path ext:a08aa7dd-dd31-4842-a4a5-0389e7383ced ;
+    form:options """{}""" ;
+    form:displayType displayTypes:files ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:8bdb4749-74cd-4299-91a2-abbf47c33474 .

--- a/tests/dummy/public/test-forms/basic-fields/meta.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/meta.ttl
@@ -1,0 +1,34 @@
+<http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>
+    a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21d1250c-6627-4111-934f-f2f7bd8c078a" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Star Rating"@en .
+
+<http://redpencil.data.gift/concepts/a6e5bd0c-c200-4834-99b3-e80198672628>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672628" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "5 stars"@en.
+
+<http://redpencil.data.gift/concepts/df2b8b6e-bcc2-4608-83da-98ab251fcf54>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df2b8b6e-bcc2-4608-83da-98ab251fcf54" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "4 stars"@en.
+
+<http://redpencil.data.gift/concepts/d3bcb263-c4e4-4512-98c8-d0b45400eebd>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3bcb263-c4e4-4512-98c8-d0b45400eebd" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "3 stars"@en.
+
+<http://redpencil.data.gift/concepts/0d5b3b23-c055-4d56-83d0-b65d28050315>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0d5b3b23-c055-4d56-83d0-b65d28050315" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "2 stars"@en.
+
+<http://redpencil.data.gift/concepts/1770b75a-95d7-4087-93d6-2c9322b7dfee>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1770b75a-95d7-4087-93d6-2c9322b7dfee" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "1 star"@en.


### PR DESCRIPTION
This adds a basic form rendering setup to the test app which should make development and testing easier. For now only the basic fields that are available in the form builder are shown, but we can always add new forms and fields when needed.

It also fixes some code that was causing issues because the prototype extensions aren't enabled in addons. #33 