### PR TITLE
Bugfix: avoid unwanted component re-render

### DIFF
--- a/addon/components/property-group.js
+++ b/addon/components/property-group.js
@@ -84,15 +84,20 @@ export default class SubmissionFormPropertyGroupComponent extends Component {
       this.children.removeObjects(deletes);
     }
 
-    // 5) insert new fields or move old fields accordingly
-    children.forEach((field, i) => {
-      const existingField = this.children.find(eField => eField.uri.equals(field.uri));
+    // 5. create a new list to render, merging already (rendered) children, with new children.
+    // We don't want to re-render components, to avoid flickering behaviour and state loss.
+    const mergedChildren = [];
+
+    for(const child of children){
+      const existingField = this.children.find(eField => eField.uri.equals(child.uri));
       if (existingField) {
-        this.children.replace(i, 1, [existingField]);
+        mergedChildren.push(existingField);
       } else {
-        this.children.replace(i, 1, [field]);
+        mergedChildren.push(child);
       }
-    });
+    }
+
+    this.children = mergedChildren;
 
     // 6) update the validation
     this.validations = validationResultsForField(group.uri, this.storeOptions);

--- a/addon/components/property-group.js
+++ b/addon/components/property-group.js
@@ -86,14 +86,14 @@ export default class SubmissionFormPropertyGroupComponent extends Component {
 
     // 5. create a new list to render, merging already (rendered) children, with new children.
     // We don't want to re-render components, to avoid flickering behaviour and state loss.
-    const mergedChildren = [];
+    const mergedChildren = A();
 
     for(const child of children){
       const existingField = this.children.find(eField => eField.uri.equals(child.uri));
       if (existingField) {
-        mergedChildren.push(existingField);
+        mergedChildren.pushObject(existingField);
       } else {
-        mergedChildren.push(child);
+        mergedChildren.pushObject(child);
       }
     }
 


### PR DESCRIPTION
Problem: Suppose these are the fields in the form
```
[ input1:state0, input2:state1]
```
Suppose `input1:state0` gets changed to `input1:state1` and thereby
triggering a dynamic subform with fields `input1.1:state0`.
The current replacing mechanism, when insering the new fields ended in
the following state
```
[ input1:state1, input1.1:state0, input2:state0]
```
This due to a wrong index replacement, destroying component `input2`
and triggering all the cleanup operations in the store.

So this is fixed and should be end up in:
```
[ input1:state1, input1.1:state0, input2:state1]
```

Note: I am unsure why replace was used, instead of just creating a new
array. It didn't seem to have any side effects and simplifies the
code.