### PR TITLE
Add a dedicated form rendering route

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   rules: {
     semi: [2, 'always'],
+    'ember/routes-segments-snake-case': 'off',
   },
   overrides: [
     // node files

--- a/tests/dummy/app/components/test-form.hbs
+++ b/tests/dummy/app/components/test-form.hbs
@@ -1,13 +1,9 @@
-{{#if this.loadFormData.isRunning}}
-  <AuLoader @padding="small" />
-{{else}}
-  <RdfForm
-    @groupClass="au-o-grid__item"
-    @form={{this.form}}
-    @graphs={{this.graphs}}
-    @sourceNode={{this.sourceNode}}
-    @formStore={{this.formStore}}
-    @show={{this.formConfig.isReadOnly}}
-    @forceShowErrors={{false}}
-  />
-{{/if}}
+<RdfForm
+  @groupClass="au-o-grid__item"
+  @form={{@form}}
+  @graphs={{this.graphs}}
+  @sourceNode={{this.sourceNode}}
+  @formStore={{@formStore}}
+  @show={{this.formConfig.isReadOnly}}
+  @forceShowErrors={{false}}
+/>

--- a/tests/dummy/app/components/test-form.js
+++ b/tests/dummy/app/components/test-form.js
@@ -1,9 +1,6 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { inject as service } from '@ember/service';
 import rdflib from 'browser-rdflib';
-import { task } from 'ember-concurrency';
 
 const FORM_GRAPHS = {
   formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
@@ -15,62 +12,9 @@ const SOURCE_NODE = new rdflib.NamedNode(
   'http://ember-submission-form-fields/source-node'
 );
 
-const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
-const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
-
 export default class TestFormComponent extends Component {
   @service formConfig;
 
-  @tracked form;
-  @tracked formStore;
   graphs = FORM_GRAPHS;
   sourceNode = SOURCE_NODE;
-
-  constructor() {
-    super(...arguments);
-
-    this.loadFormData.perform();
-  }
-
-  @task
-  *loadFormData() {
-    let formName = this.args.name;
-
-    let [formTtl, metaTtl] = yield Promise.all([
-      fetchForm(formName),
-      fetchFormMeta(formName),
-    ]);
-
-    let formStore = new ForkingStore();
-    formStore.parse(formTtl, FORM_GRAPHS.formGraph, 'text/turtle');
-    formStore.parse(metaTtl, FORM_GRAPHS.metaGraph, 'text/turtle');
-
-    let form = formStore.any(
-      undefined,
-      RDF('type'),
-      FORM('Form'),
-      FORM_GRAPHS.formGraph
-    );
-
-    this.form = form;
-    this.formStore = formStore;
-  }
-}
-
-async function fetchForm(formName) {
-  let response = await fetch(getFormDataPath(formName, 'form.ttl'));
-  let ttl = await response.text();
-
-  return ttl;
-}
-
-async function fetchFormMeta(formName) {
-  let response = await fetch(getFormDataPath(formName, 'meta.ttl'));
-  let ttl = await response.text();
-
-  return ttl;
-}
-
-function getFormDataPath(formName, fileName) {
-  return `/test-forms/${formName}/${fileName}`;
 }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,6 @@ export default class Router extends EmberRouter {
   rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+  this.route('form', { path: ':formName' });
+});

--- a/tests/dummy/app/routes/form.js
+++ b/tests/dummy/app/routes/form.js
@@ -1,0 +1,63 @@
+import Route from '@ember/routing/route';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import rdflib from 'browser-rdflib';
+
+const FORM_GRAPHS = {
+  formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
+  metaGraph: new rdflib.NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`),
+};
+
+const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
+const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+
+const FORM_TITLES = {
+  'basic-fields': 'Basic form fields',
+};
+
+export default class FormRoute extends Route {
+  async model({ formName }) {
+    let [formTtl, metaTtl] = await Promise.all([
+      fetchForm(formName),
+      fetchFormMeta(formName),
+    ]);
+
+    let formStore = new ForkingStore();
+    formStore.parse(formTtl, FORM_GRAPHS.formGraph, 'text/turtle');
+    formStore.parse(metaTtl, FORM_GRAPHS.metaGraph, 'text/turtle');
+
+    let form = formStore.any(
+      undefined,
+      RDF('type'),
+      FORM('Form'),
+      FORM_GRAPHS.formGraph
+    );
+
+    this.form = form;
+    this.formStore = formStore;
+    return {
+      formName,
+      form,
+      formStore,
+      title: FORM_TITLES[formName],
+    };
+  }
+}
+
+async function fetchForm(formName) {
+  let response = await fetch(getFormDataPath(formName, 'form.ttl'));
+  let ttl = await response.text();
+
+  return ttl;
+}
+
+async function fetchFormMeta(formName) {
+  let response = await fetch(getFormDataPath(formName, 'meta.ttl'));
+  let ttl = await response.text();
+
+  return ttl;
+}
+
+function getFormDataPath(formName, fileName) {
+  return `/test-forms/${formName}/${fileName}`;
+}

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class FormRoute extends Route {
+  @service router;
+
+  beforeModel() {
+    this.router.replaceWith('form', 'basic-fields');
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -9,7 +9,7 @@
           <nav>
             <ul class="au-c-list-navigation">
               <li class="au-c-list-navigation__item">
-                <AuNavigationLink @route="index">
+                <AuNavigationLink @route="form" @model="basic-fields">
                   Basic form fields
                 </AuNavigationLink>
               </li>

--- a/tests/dummy/app/templates/form.hbs
+++ b/tests/dummy/app/templates/form.hbs
@@ -1,0 +1,6 @@
+{{page-title @model.title}}
+
+<TestForm
+  @form={{@model.form}}
+  @formStore={{@model.formStore}}
+/>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,0 @@
-{{page-title "Basic fields"}}
-
-<TestForm @name="basic-fields" />

--- a/tests/dummy/app/templates/loading.hbs
+++ b/tests/dummy/app/templates/loading.hbs
@@ -1,0 +1,1 @@
+<AuLoader @padding="small" />


### PR DESCRIPTION
This makes it easier to add new forms by simply creating the needed files and linking to the form route with the form name.

I've split it off from #48 since it's not really related to that.