### PR TITLE
Fix the heading levels

### DIFF
--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -2,7 +2,7 @@
   <div ...attributes>
     {{#if @group.name}}
       <div class="au-u-margin-bottom-small">
-        <AuHeading @level={{this.level}} @skin={{add this.level 1}}>
+        <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
           {{@group.name}}
         </AuHeading>
         {{#if @group.help}}
@@ -38,7 +38,7 @@
         </div>
       {{else}}
         <PropertyGroup
-                @level={{add this.level 1}}
+                @level={{this.nextLevel}}
                 @form={{@form}}
                 @group={{child}}
                 @formStore={{@formStore}}

--- a/addon/components/property-group.js
+++ b/addon/components/property-group.js
@@ -34,6 +34,18 @@ export default class SubmissionFormPropertyGroupComponent extends Component {
     return this.args.level || 1;
   }
 
+  get titleLevel() {
+    return `${this.level}`;
+  }
+
+  get titleSkin() {
+    return `${this.level + 1}`;
+  }
+
+  get nextLevel() {
+    return this.level + 1;
+  }
+
   get errors() {
     return this.validations.filter((r) => !r.valid);
   }


### PR DESCRIPTION
We were passing a number into the `@level` argument of the `AuHeading` component. This component uses the `eq` helper to compare the values which is a strict equal so non of the values matched and it always defaulted to a h1. `{{eq 2 "2"}}` will return `false`.

This change should result in the proper title being used.