### PR TITLE
Parse field options in the field model

### DIFF
--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
@@ -29,7 +29,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorEditCompone
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = JSON.parse(this.args.field.options);
+    const fieldOptions = this.args.field.options;
     const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore

--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
@@ -25,7 +25,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowCompone
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = JSON.parse(this.args.field.options);
+    const fieldOptions = this.args.field.options;
     const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.js
@@ -85,12 +85,7 @@ export default class CustomSubsidyFormFieldsEstimatedCostTableEditComponent exte
   }
 
   get isAanvraagStep() {
-    if (this.args.field && this.args.field.options) {
-      const option = JSON.parse(this.args.field.options);
-      return option.isAanvraagStep;
-    } else {
-      return false;
-    }
+    return Boolean(this.args.field?.options?.isAanvraagStep);
   }
 
   initializeTable() {

--- a/addon/components/rdf-input-fields/case-number.js
+++ b/addon/components/rdf-input-fields/case-number.js
@@ -51,7 +51,7 @@ export default class RdfInputFieldsCaseNumberComponent extends SimpleInputFieldC
   }
 
   setRandomCaseNumber() {
-    const options = JSON.parse(this.args.field.options);
+    const options = this.args.field.options;
     let url = `/case-number-generator/generate?node=${this.storeOptions.sourceNode.value}`;
     if (options.prefix) {
       url = url + `&prefix=${options.prefix}`;

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -52,7 +52,7 @@ export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent e
     const store = this.args.formStore;
     const { sourceGraph, metaGraph } = this.args.graphs;
     const path = this.args.field.rdflibPath;
-    const options = JSON.parse(this.args.field.options);
+    const options = this.args.field.options;
     const scheme = new rdflib.namedNode(options.conceptScheme);
 
     let orderBy;

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -35,7 +35,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = JSON.parse(this.args.field.options);
+    const fieldOptions = this.args.field.options;
     const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
 
     /**

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -17,7 +17,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = JSON.parse(this.args.field.options);
+    const fieldOptions = this.args.field.options;
     const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -30,7 +30,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = JSON.parse(this.args.field.options);
+    const fieldOptions = this.args.field.options;
     const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
 
     /**

--- a/addon/models/field.js
+++ b/addon/models/field.js
@@ -77,7 +77,15 @@ export default class FieldModel {
   @tracked
   rdflibOptions = null;
   get options() {
-    return this.rdflibOptions && this.rdflibOptions.value;
+    let options;
+
+    try {
+      options = JSON.parse(this.rdflibOptions?.value);
+    } catch {
+      options = {};
+    }
+
+    return options;
   }
 
   @tracked

--- a/addon/models/field.js
+++ b/addon/models/field.js
@@ -89,7 +89,7 @@ export default class FieldModel {
   }
 
   @tracked
-  rdflibOptions = null;
+  rdflibDefaultValue = null;
   get defaultValue() {
     return this.rdflibDefaultValue && this.rdflibDefaultValue.value;
   }


### PR DESCRIPTION
I noticed a lot of components were using JSON.parse to read the field options. We can simplify all this code by doing the work in the field model instead.