### PR TITLE
Make sure that the accordion subtitles are shown

### DIFF
--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/accordion.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/accordion.hbs
@@ -1,8 +1,8 @@
 <AuAccordion
-  @accordionIconOpen="nav-up"
-  @accordionIconClosed="nav-down"
-  @accordionButtonLabel={{@label}}
-  @accordionSubTitle={{@subtitle}}
-  >
+  @iconOpen="nav-up"
+  @iconClosed="nav-down"
+  @buttonLabel={{@label}}
+  @subtitle={{@subtitle}}
+>
   {{yield}}
 </AuAccordion>


### PR DESCRIPTION
The appuniversum update included a change which deprecated some of the AuAccordion arguments and replaced them with a shorter version. The fallback behavior contains a typo which means the subtitle was no longer being shown. Switching to the new argument name resolves the issue and also fixes the deprecation messages.

More information: https://github.com/appuniversum/ember-appuniversum/issues/221