### PR TITLE
Enable the "burgemeesterconvenant" row for the edit table

### DIFF
--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/edit.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/edit.hbs
@@ -44,7 +44,7 @@
   </thead>
   <tbody>
     {{#if this.climateTableSubject}}
-      {{!--<CustomSubsidyFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters
+      <CustomSubsidyFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters
         @storeOptions={{this.storeOptions}}
         @businessRuleUriStr="http://data.lblod.info/id/subsidies/rules/0f4e3cff-4fb8-4892-9dca-1d582a433c77"
         @climateTableSubject={{this.climateTableSubject}}
@@ -52,7 +52,6 @@
         @updateTotalRestitution={{this.updateTotaleRestitution}}
         @onUpdateRow={{this.validate}}
         as |row|>
-
         <row.actionDescription>
           <CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion
             @label="Algemene beleidsdoelstellingen:"
@@ -65,7 +64,7 @@
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
 
-      </CustomSubsidyFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters>--}}
+      </CustomSubsidyFormFields::ClimateSubsidyCostsTable::TableRowBurgemeesters>
 
       <CustomSubsidyFormFields::ClimateSubsidyCostsTable::TableRowVastgoedplan
         @storeOptions={{this.storeOptions}}


### PR DESCRIPTION
This row was disabled a while ago but only in the edit table. This makes it consistent with the show table.