### PR TITLE
Use `@disabled` instead of `disabled`

### DIFF
--- a/addon/components/custom-subsidy-form-fields/application-form-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/application-form-table/show.hbs
@@ -29,7 +29,7 @@
       <tr>
         <td>
           <AuLabel for="actor-name-{{index}}" class="au-u-hidden-visually">Naam organisator</AuLabel>
-          <AuInput id="actor-name-{{index}}" @width="block" @value={{entry.actorName.value}} disabled={{true}}/>
+          <AuInput id="actor-name-{{index}}" @width="block" @value={{entry.actorName.value}} @disabled={{true}}/>
         </td>
         <td>
           <AuLabel for="all-day-{{index}}" class="au-u-hidden-visually">
@@ -37,7 +37,7 @@
             <br>
             met personeel
           </AuLabel>
-          <AuInput id="all-day-{{index}}" @width="block" @value={{entry.numberChildrenForFullDay.value}} disabled={{true}}/>
+          <AuInput id="all-day-{{index}}" @width="block" @value={{entry.numberChildrenForFullDay.value}} @disabled={{true}}/>
         </td>
         <td>
           <AuLabel for="half-day-{{index}}"  class="au-u-hidden-visually">
@@ -45,7 +45,7 @@
             <br>
             met personeel
           </AuLabel>
-          <AuInput id="half-day-{{index}}" @width="block" @value={{entry.numberChildrenForHalfDay.value}} disabled={{true}}/>
+          <AuInput id="half-day-{{index}}" @width="block" @value={{entry.numberChildrenForHalfDay.value}} @disabled={{true}}/>
         </td>
         <td>
           <AuLabel for="per-infra-{{index}}" class="au-u-hidden-visually">
@@ -53,7 +53,7 @@
             <br>
             met of zonder personeel
           </AuLabel>
-          <AuInput id="per-infra-{{index}}" @width="block" @value={{entry.numberChildrenPerInfrastructure.value}} disabled={{true}}/>
+          <AuInput id="per-infra-{{index}}" @width="block" @value={{entry.numberChildrenPerInfrastructure.value}} @disabled={{true}}/>
         </td>
         <td style="white-space: nowrap; vertical-align: middle;" {{! template-lint-disable no-inline-styles }}>
           €&hairsp;{{entry.totalAmount}}

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
@@ -4,7 +4,7 @@
   </th>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"
@@ -21,7 +21,7 @@
   </td>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
@@ -4,7 +4,7 @@
   </th>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"
@@ -21,7 +21,7 @@
   </td>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
@@ -4,7 +4,7 @@
   </th>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"
@@ -19,7 +19,7 @@
   </td>
   <td>
     <AuInput
-      disabled={{@disabled}}
+      @disabled={{@disabled}}
       type="number"
       lang="nl-BE"
       @width="block"

--- a/addon/components/custom-subsidy-form-fields/engagement-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/engagement-table/show.hbs
@@ -28,19 +28,19 @@
           <AuLabel for="existing-staff-{{index}}" class="au-u-hidden-visually">
             Bestaand personeelskader
           </AuLabel>
-          <AuInput id="existing-staff-{{index}}" @width="block" @value={{entry.existingStaff.value}} disabled={{true}} type="number"/>
+          <AuInput id="existing-staff-{{index}}" @width="block" @value={{entry.existingStaff.value}} @disabled={{true}} type="number"/>
         </td>
         <td>
           <AuLabel for="additional-staff-{{index}}" class="au-u-hidden-visually">
             (Tijdelijk) extra aangeworven betaald personeel
           </AuLabel>
-          <AuInput id="additional-staff-{{index}}" @width="block" @value={{entry.additionalStaff.value}} disabled={{true}} type="number"/>
+          <AuInput id="additional-staff-{{index}}" @width="block" @value={{entry.additionalStaff.value}} @disabled={{true}} type="number"/>
         </td>
         <td>
           <AuLabel for="volunteers-{{index}}" class="au-u-hidden-visually">
             Vrijwilligers
           </AuLabel>
-          <AuInput id="volunteers-{{index}}" @width="block" @value={{entry.volunteers.value}} disabled={{true}} type="number"/>
+          <AuInput id="volunteers-{{index}}" @width="block" @value={{entry.volunteers.value}} @disabled={{true}} type="number"/>
         </td>
       </tr>
     {{/each}}

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
@@ -28,7 +28,7 @@
           <AuLabel for="costs-{{index}}" class="au-u-hidden-visually">
             Kosten (Excl. BTW)
           </AuLabel>
-          <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}} disabled={{true}}
+          <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}} @disabled={{true}}
             type="number"
           />
         </td>
@@ -36,7 +36,7 @@
           <AuLabel for="share-{{index}}" class="au-u-hidden-visually">
             Het gemeentelijk aandeel (%) in kosten
           </AuLabel>
-          <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}} disabled={{true}}
+          <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}} @disabled={{true}}
             type="number"
           />
         </td>

--- a/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
+++ b/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
@@ -1,6 +1,6 @@
 <td headers={{@tableHeaders}}>
   <AuInput
-    disabled={{@disabled}}
+    @disabled={{@disabled}}
     type="number"
     lang="nl-BE"
     @width="block"

--- a/addon/components/search-panel-fields/search/show.hbs
+++ b/addon/components/search-panel-fields/search/show.hbs
@@ -3,7 +3,7 @@
 </AuLabel>
 <AuInput
   id="{{this.inputId}}"
-  disabled={{true}}
+  @disabled={{true}}
   @width="block"
   @value={{this.value}}
 />


### PR DESCRIPTION
I noticed not all components where using the `@disabled` argument yet which means they visually didn't look disabled.

Before:
![image](https://user-images.githubusercontent.com/3533236/161227272-8ca04823-4143-4c4a-bdd1-41ae13edfe74.png)

After:
![image](https://user-images.githubusercontent.com/3533236/161227361-4865b0f1-4628-46ce-9d1f-a460c86dc831.png)
