### PR TITLE
Fix climate table row links

### DIFF
--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table.hbs
@@ -138,9 +138,9 @@
             @subtitle="Investeringssteun voor het planten van bomen op publiek"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -167,9 +167,9 @@
             @subtitle="Investeringssteun voor het planten van bomen op privaat domein (door particulieren, verenigingen, KMO's)"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -195,9 +195,9 @@
             @subtitle="Investeringssteun voor het planten van hagen (per meter) op publiek domein"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -223,9 +223,9 @@
             @subtitle="Investeringssteun voor het planten van hagen (per meter) op privaat domein (door particulieren, verenigingen en KMO's)"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -252,9 +252,9 @@
             @subtitle="Investeringssteun geveltuinbeplanting (type geveltuin, per meter) door particulieren"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -281,9 +281,9 @@
             @subtitle="Investeringssteun aanleg natuurgroenperk van minimaal 10 m² op openbaar toegankelijk domein"
           >
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening"
+              href="https://www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening"
             >
-              www.vvsg.be/kennisitem/laten-we-een-boom-opzetten-vergroening
+              www.vvsg.be/kennisitem/vvsg/laten-we-een-boom-opzetten-vergroening
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -318,9 +318,9 @@
               begeleiding van renovaties i.h.k.v. het noodkoopfonds.)
             </p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie"
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
             >
-              www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie
+              www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie
             </AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
@@ -357,8 +357,8 @@
               >(https://apps.energiesparen.be/energiekaart/vlaanderen/cooperaties).</AuLinkExternal>
             </p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie"
-            >www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie</AuLinkExternal>
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
+            >www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>
@@ -390,8 +390,8 @@
               de integratie met laad- en mobiliteitsoplossingen op wijkniveau.
             </p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie"
-            >www.vvsg.be/kennisitem/verrijk-je-wijk-renovatie-hernieuwbare-energie</AuLinkExternal>
+              href="https://www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie"
+            >www.vvsg.be/kennisitem/vvsg/verrijk-je-wijk-energie</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>
@@ -426,8 +426,8 @@
               opgevolgd.
             </p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/elke-buurt-deel-en-is-duurzaam-bereikbaar-koolstofvrije-deelmobiliteit"
-            >www.vvsg.be/kennisitem/elke-buurt-deel-en-is-duurzaam-bereikbaar-koolstofvrije-deelmobiliteit</AuLinkExternal>
+              href="https://www.vvsg.be/kennisitem/vvsg/elke-buurt-deelt-en-is-duurzaam-bereikbaar"
+            >www.vvsg.be/kennisitem/vvsg/elke-buurt-deelt-en-is-duurzaam-bereikbaar</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>
@@ -455,8 +455,8 @@
               Vlaanderenbreed geïnventariseerd door AGIV.
             </p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek"
-            >www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+              href="https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>
@@ -483,8 +483,8 @@
             <p>Verharding stemt overeen met de term ‘bodemafdekking’ zoals
               Vlaanderenbreed geïnventariseerd door AGIV.</p>
             <AuLinkExternal
-              href="https://www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek"
-            >www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+              href="https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>
@@ -518,8 +518,8 @@
               voorzien wordt bij appartementsgebouwen, wordt wel meegeteld.
             </p>
             <AuLinkExternal
-              href="https://https://www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek"
-            >www.vvsg.be/kennisitem/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
+              href="https://https://www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek"
+            >www.vvsg.be/kennisitem/vvsg/water-het-nieuwe-goud-droogteproblematiek</AuLinkExternal>
           </CustomSubsidyFormFields::ClimateSubsidyCostsTable::Accordion>
         </row.actionDescription>
         <row.costPerUnitDescription>


### PR DESCRIPTION
This fixes the broken links in the climate table row descriptions.

Builds on #48 since that overhauls the component.