### PR TITLE
Custom form field component registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,36 @@ ember install ember-submission-form-fields
 Usage
 ------------------------------------------------------------------------------
 
-[Longer description of how to use the addon in apps.]
+### Registering new form field components
 
+If your app wants to support display types that aren't supported by the built-in components you can use the `registerFormFields` util.
+
+The utility accepts an array of objects with the following structure:
+```ts
+type FormFieldRegistration = {
+  displayType: string;
+  edit: Component;
+  show?: Component;
+}
+```
+
+The "show" component is optional. If it isn't provided we fall back to the edit component. This allows you to use a single component for both the "edit" and "show" states of the form which is useful when both variants aren't that much different. The custom component receive the same arguments as the built-in components so you can use `@show` if you need to conditional behavior based on the form state.
+
+Registering components can be done wherever you want, as long as it's done before the form is being rendered.
+
+> Note: It's not allowed to register components with a display type that's already handled by one of the built-in components.
+
+#### Usage example
+
+```js
+import { registerFormFields } from '@lblod/ember-submission-form-fields';
+import SomeFormFieldComponent from 'project/components/some-form-field-component';
+
+registerFormFields([{
+  displayType: 'http://some-display-type-uri',
+  edit: SomeFormFieldComponent
+}]);
+```
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,6 +4,7 @@ import {
 } from '@lblod/submission-form-helpers';
 import { delGraphFor, addGraphFor } from 'forking-store';
 import ForkingStore from 'forking-store';
+
 export {
   importTriplesForForm,
   validateForm,
@@ -11,3 +12,5 @@ export {
   delGraphFor,
   addGraphFor,
 };
+
+export { registerFormFields } from '@lblod/ember-submission-form-fields/utils/display-type';

--- a/tests/unit/utils/display-type-test.js
+++ b/tests/unit/utils/display-type-test.js
@@ -1,0 +1,65 @@
+import { setComponentTemplate } from '@ember/component';
+import templateOnlyComponent from '@ember/component/template-only';
+import {
+  getComponentForDisplayType,
+  registerComponentsForDisplayType,
+  resetBuiltInComponentRegistrations,
+  resetCustomComponentRegistrations,
+} from '@lblod/ember-submission-form-fields/utils/display-type';
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Unit | Utility | display-type', function () {
+  module('getComponentForDisplayType', function (hooks) {
+    hooks.beforeEach(function () {
+      resetBuiltInComponentRegistrations();
+      resetCustomComponentRegistrations();
+    });
+
+    const TEST_DISPLAY_TYPE = 'http://lblod.data.gift/display-types/hello';
+
+    let EditComponent = setComponentTemplate(
+      hbs`edit`,
+      templateOnlyComponent()
+    );
+    let ShowComponent = setComponentTemplate(
+      hbs`show`,
+      templateOnlyComponent()
+    );
+
+    test('it returns a component for a given display type URI', function (assert) {
+      registerComponentsForDisplayType([
+        {
+          displayType: TEST_DISPLAY_TYPE,
+          edit: EditComponent,
+          show: ShowComponent,
+        },
+      ]);
+
+      let FieldComponent = getComponentForDisplayType(TEST_DISPLAY_TYPE);
+      assert.strictEqual(
+        FieldComponent,
+        EditComponent,
+        'it returns the edit component'
+      );
+
+      FieldComponent = getComponentForDisplayType(
+        TEST_DISPLAY_TYPE,
+        true,
+        'it returns the show component'
+      );
+      assert.strictEqual(FieldComponent, ShowComponent);
+    });
+
+    test('it throws an error if a display type has no corresponding component', function (assert) {
+      assert.expect(1);
+      assert.throws(() => {
+        let FieldComponent = getComponentForDisplayType(
+          'http://lblod.data.gift/display-types/not-registered'
+        );
+
+        assert.notOk(FieldComponent, 'no component class was returned');
+      }, 'it throws an error');
+    });
+  });
+});

--- a/tests/unit/utils/register-form-fields-test.js
+++ b/tests/unit/utils/register-form-fields-test.js
@@ -1,0 +1,180 @@
+import { setComponentTemplate } from '@ember/component';
+import templateOnlyComponent from '@ember/component/template-only';
+import { registerFormFields } from '@lblod/ember-submission-form-fields';
+import {
+  getComponentForDisplayType,
+  registerComponentsForDisplayType,
+  resetCustomComponentRegistrations,
+} from '@lblod/ember-submission-form-fields/utils/display-type';
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Unit | Utility | registerFormFields', function (hooks) {
+  hooks.beforeEach(function () {
+    resetCustomComponentRegistrations();
+  });
+
+  let EditComponent = setComponentTemplate(hbs`edit`, templateOnlyComponent());
+  let ShowComponent = setComponentTemplate(hbs`show`, templateOnlyComponent());
+
+  test("it's possible to register new form field components", function (assert) {
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: EditComponent,
+        show: ShowComponent,
+      },
+    ]);
+
+    let FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello'
+    );
+    assert.strictEqual(EditComponent, FieldComponent);
+
+    FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello',
+      true
+    );
+    assert.strictEqual(ShowComponent, FieldComponent);
+  });
+
+  test('it uses the edit component as a fallback for the show component', function (assert) {
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: EditComponent,
+      },
+    ]);
+
+    let FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello'
+    );
+    assert.strictEqual(EditComponent, FieldComponent);
+
+    FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello',
+      true
+    );
+    assert.strictEqual(EditComponent, FieldComponent);
+  });
+
+  test('it can override previously registered components for a certain display type', function (assert) {
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: EditComponent,
+        show: ShowComponent,
+      },
+    ]);
+
+    let ComponentOverride = setComponentTemplate(
+      hbs`override`,
+      templateOnlyComponent()
+    );
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: ComponentOverride,
+      },
+    ]);
+
+    let FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello'
+    );
+    assert.strictEqual(
+      ComponentOverride,
+      FieldComponent,
+      'it returns the new edit component'
+    );
+
+    FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello',
+      true
+    );
+    assert.strictEqual(
+      ShowComponent,
+      FieldComponent,
+      'it returns the previous show component'
+    );
+
+    registerFormFields([
+      {
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: ComponentOverride,
+        show: ComponentOverride,
+      },
+    ]);
+
+    FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello'
+    );
+    assert.strictEqual(
+      ComponentOverride,
+      FieldComponent,
+      'it returns the new edit component'
+    );
+
+    FieldComponent = getComponentForDisplayType(
+      'http://lblod.data.gift/display-types/hello',
+      true
+    );
+    assert.strictEqual(
+      ComponentOverride,
+      FieldComponent,
+      'it returns the new show component'
+    );
+  });
+
+  test('it throws an error if no array is provided', function (assert) {
+    assert.throws(() => {
+      registerFormFields({
+        displayType: 'http://lblod.data.gift/display-types/hello',
+        edit: EditComponent,
+      });
+    }, /The form fields should be provided as an array/);
+  });
+
+  test('it throws an error if no display type is provided', function (assert) {
+    assert.throws(() => {
+      registerFormFields([
+        {
+          edit: EditComponent,
+        },
+      ]);
+    }, /`displayType` is required when registering a form field/);
+  });
+
+  test('it throws an error when trying to override a built-in display type', function (assert) {
+    registerComponentsForDisplayType([
+      {
+        displayType: 'http://lblod.data.gift/display-types/built-in',
+        edit: EditComponent,
+      },
+    ]);
+
+    let ComponentOverride = setComponentTemplate(
+      hbs`override`,
+      templateOnlyComponent()
+    );
+
+    assert.throws(() => {
+      registerFormFields([
+        {
+          displayType: 'http://lblod.data.gift/display-types/built-in',
+          edit: ComponentOverride,
+        },
+      ]);
+    }, /Registering a component for the 'http:\/\/lblod\.data\.gift\/display-types\/built-in' display type isn't allowed since a built-in component already handles it./);
+  });
+
+  test('it throws an error if no edit component is provided', function (assert) {
+    assert.throws(() => {
+      registerFormFields([
+        {
+          displayType: 'http://lblod.data.gift/display-types/hello',
+          show: ShowComponent,
+        },
+      ]);
+    }, /The edit component is required when registering custom fields/);
+  });
+});


### PR DESCRIPTION
This adds a 'registerFormFields' util that can be used to register custom form field components. That way not all components need to be bundled with this addon making it a more generic solution.

Closes #41 