### PR TITLE
Add flags to disable some of the built-in components

### DIFF
--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import { getOwnConfig, macroCondition } from '@embroider/macros';
+import { getOwnConfig, importSync, macroCondition } from '@embroider/macros';
 
 // Basic fields
 import BestuursorgaanSelectorEditComponent from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/edit';
@@ -22,25 +22,6 @@ import RemoteUrlsShowComponent from '@lblod/ember-submission-form-fields/compone
 import SwitchComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/switch';
 import TextAreaComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/text-area';
 import VlabelOpcentiemComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/vlabel-opcentiem';
-
-// Search related fields
-import CustomSearchEditComponent from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/edit';
-import CustomSearchShowComponent from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/show';
-import DateRangeComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-range';
-import SearchComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/search';
-
-// Custom table components
-import ApplicationFormTableEditComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/application-form-table/edit';
-import ApplicationFormTableShowComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/application-form-table/show';
-import ClimateSubsidyCostsTableComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/climate-subsidy-costs-table';
-import EngagementTableEditComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/engagement-table/edit';
-import EngagementTableShowComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/engagement-table/show';
-import EstimatedCostEditComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/estimated-cost-table/edit';
-import EstimatedCostShowComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/estimated-cost-table/show';
-import ObjectiveTableEditComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/objective-table/edit';
-import ObjectiveTableShowComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/objective-table/show';
-import PlanLivingTogetherTableEditComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/plan-living-together-table/edit';
-import PlanLivingTogetherTableShowComponent from '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/plan-living-together-table/show';
 
 const BUILT_IN_EDIT_COMPONENTS = new Map();
 const BUILT_IN_SHOW_COMPONENTS = new Map();
@@ -234,16 +215,24 @@ if (macroCondition(getOwnConfig().includeSearchComponents)) {
   registerComponentsForDisplayType([
     {
       displayType: 'http://lblod.data.gift/display-types/customSearch',
-      edit: CustomSearchEditComponent,
-      show: CustomSearchShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/search-panel-fields/search/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/search-panel-fields/search/show'
+      ).default,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/dateRange',
-      edit: DateRangeComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-range'
+      ).default,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/search',
-      edit: SearchComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/rdf-input-fields/search'
+      ).default,
     },
   ]);
 }
@@ -253,34 +242,56 @@ if (macroCondition(getOwnConfig().includeTableComponents)) {
   registerComponentsForDisplayType([
     {
       displayType: 'http://lblod.data.gift/display-types/applicationFormTable',
-      edit: ApplicationFormTableEditComponent,
-      show: ApplicationFormTableShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/application-form-table/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/application-form-table/show'
+      ).default,
     },
     {
       displayType:
         'http://lblod.data.gift/display-types/climateSubsidyCostTable',
-      edit: ClimateSubsidyCostsTableComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/climate-subsidy-costs-table'
+      ).default,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/engagementTable',
-      edit: EngagementTableEditComponent,
-      show: EngagementTableShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/engagement-table/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/engagement-table/show'
+      ).default,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/estimatedCostTable',
-      edit: EstimatedCostEditComponent,
-      show: EstimatedCostShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/estimated-cost-table/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/estimated-cost-table/show'
+      ).default,
     },
     {
       displayType: 'http://lblod.data.gift/display-types/objectiveTable',
-      edit: ObjectiveTableEditComponent,
-      show: ObjectiveTableShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/objective-table/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/objective-table/show'
+      ).default,
     },
     {
       displayType:
         'http://lblod.data.gift/display-types/planLivingTogetherTable',
-      edit: PlanLivingTogetherTableEditComponent,
-      show: PlanLivingTogetherTableShowComponent,
+      edit: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/plan-living-together-table/edit'
+      ).default,
+      show: importSync(
+        '@lblod/ember-submission-form-fields/components/custom-subsidy-form-fields/plan-living-together-table/show'
+      ).default,
     },
   ]);
 }

--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -1,4 +1,5 @@
 import { assert } from '@ember/debug';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 
 // Basic fields
 import BestuursorgaanSelectorEditComponent from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/edit';
@@ -226,50 +227,60 @@ registerComponentsForDisplayType([
     displayType: 'http://lblod.data.gift/display-types/vLabelOpcentiem',
     edit: VlabelOpcentiemComponent,
   },
-
-  // Search related fields
-  {
-    displayType: 'http://lblod.data.gift/display-types/customSearch',
-    edit: CustomSearchEditComponent,
-    show: CustomSearchShowComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/dateRange',
-    edit: DateRangeComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/search',
-    edit: SearchComponent,
-  },
-
-  // Custom table components
-  {
-    displayType: 'http://lblod.data.gift/display-types/applicationFormTable',
-    edit: ApplicationFormTableEditComponent,
-    show: ApplicationFormTableShowComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/climateSubsidyCostTable',
-    edit: ClimateSubsidyCostsTableComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/engagementTable',
-    edit: EngagementTableEditComponent,
-    show: EngagementTableShowComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/estimatedCostTable',
-    edit: EstimatedCostEditComponent,
-    show: EstimatedCostShowComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/objectiveTable',
-    edit: ObjectiveTableEditComponent,
-    show: ObjectiveTableShowComponent,
-  },
-  {
-    displayType: 'http://lblod.data.gift/display-types/planLivingTogetherTable',
-    edit: PlanLivingTogetherTableEditComponent,
-    show: PlanLivingTogetherTableShowComponent,
-  },
 ]);
+
+// Search related fields
+if (macroCondition(getOwnConfig().includeSearchComponents)) {
+  registerComponentsForDisplayType([
+    {
+      displayType: 'http://lblod.data.gift/display-types/customSearch',
+      edit: CustomSearchEditComponent,
+      show: CustomSearchShowComponent,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/dateRange',
+      edit: DateRangeComponent,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/search',
+      edit: SearchComponent,
+    },
+  ]);
+}
+
+// Custom table components
+if (macroCondition(getOwnConfig().includeTableComponents)) {
+  registerComponentsForDisplayType([
+    {
+      displayType: 'http://lblod.data.gift/display-types/applicationFormTable',
+      edit: ApplicationFormTableEditComponent,
+      show: ApplicationFormTableShowComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/climateSubsidyCostTable',
+      edit: ClimateSubsidyCostsTableComponent,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/engagementTable',
+      edit: EngagementTableEditComponent,
+      show: EngagementTableShowComponent,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/estimatedCostTable',
+      edit: EstimatedCostEditComponent,
+      show: EstimatedCostShowComponent,
+    },
+    {
+      displayType: 'http://lblod.data.gift/display-types/objectiveTable',
+      edit: ObjectiveTableEditComponent,
+      show: ObjectiveTableShowComponent,
+    },
+    {
+      displayType:
+        'http://lblod.data.gift/display-types/planLivingTogetherTable',
+      edit: PlanLivingTogetherTableEditComponent,
+      show: PlanLivingTogetherTableShowComponent,
+    },
+  ]);
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Funnel = require('broccoli-funnel');
+
 module.exports = {
   name: require('./package').name,
   options: {
@@ -19,5 +21,36 @@ module.exports = {
       let ownConfig = this.options['@embroider/macros'].setOwnConfig;
       Object.assign(ownConfig, addonOptions);
     }
+  },
+
+  treeForAddon: function (tree) {
+    tree = this.filterUnneededComponents(tree);
+    return this._super.treeForAddon.call(this, tree);
+  },
+
+  treeForApp: function (tree) {
+    tree = this.filterUnneededComponents(tree);
+    return this._super.treeForApp.call(this, tree);
+  },
+
+  filterUnneededComponents: function (tree) {
+    let exclude = [];
+    let ownConfig = this.options['@embroider/macros'].setOwnConfig;
+
+    if (!ownConfig.includeTableComponents) {
+      exclude.push('components/custom-subsidy-form-fields/**/*');
+    }
+
+    if (!ownConfig.includeSearchComponents) {
+      exclude.push(
+        'components/search-panel-fields/**/*',
+        'components/rdf-input-fields/date-range.*',
+        'components/rdf-input-fields/search.*'
+      );
+    }
+
+    return new Funnel(tree, {
+      exclude,
+    });
   },
 };

--- a/index.js
+++ b/index.js
@@ -2,4 +2,22 @@
 
 module.exports = {
   name: require('./package').name,
+  options: {
+    '@embroider/macros': {
+      setOwnConfig: {
+        includeTableComponents: true,
+        includeSearchComponents: true,
+      },
+    },
+  },
+
+  included: function (app) {
+    this._super.included.apply(this, arguments);
+
+    let addonOptions = app.options[this.name];
+    if (addonOptions) {
+      let ownConfig = this.options['@embroider/macros'].setOwnConfig;
+      Object.assign(ownConfig, addonOptions);
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/util": "^1.0.0",
+    "@embroider/macros": "^1.6.0",
+    "@embroider/util": "^1.6.0",
     "@lblod/submission-form-helpers": "^1.3.0",
     "browser-rdflib": "^1.1.0",
     "clipboardy": "^2.3.0",
@@ -95,8 +96,8 @@
     "sass": "^1.49.8"
   },
   "overrides": {
-    "@embroider/macros": "^1.0.0",
-    "@embroider/util": "^1.0.0"
+    "@embroider/macros": "^1.6.0",
+    "@embroider/util": "^1.6.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@embroider/macros": "^1.6.0",
     "@embroider/util": "^1.6.0",
     "@lblod/submission-form-helpers": "^1.3.0",
+    "broccoli-funnel": "^3.0.8",
     "browser-rdflib": "^1.1.0",
     "clipboardy": "^2.3.0",
     "ember-auto-import": "^2.2.4",


### PR DESCRIPTION
This adds a configuration flag which can be used to disable the "custom" component registrations. This allows us to register these components from the app without triggering an error message. In the next major release we can then remove these components from the addon.

It can be used like this:
```js
// ember-cli-build.js
let app = new EmberApp(defaults, {
  '@lblod/ember-submission-form-fields': {
    includeTableComponents: false,
    includeSearchComponents: false,
  },
});
```

The components will be removed from the final bundle. Especially the table components have a large impact on bundle size:
`includeTableComponents: true`: `dist/assets/vendor.js: 1.37 MB (301.7 KB gzipped)`
vs
`includeTableComponents: false`: `dist/assets/vendor.js: 1.15 MB (273.75 KB gzipped)`

So close to 30KB of code that is no longer shipped if you don't need the table components.

Builds on #65 