### PR TITLE
Ensure checkboxes show the correct checked state when data is loaded

### DIFF
--- a/addon/components/rdf-input-fields/checkbox.hbs
+++ b/addon/components/rdf-input-fields/checkbox.hbs
@@ -10,7 +10,7 @@
   @label={{@field.label}}
   @disabled={{@show}}
   @onChange={{this.updateValue}}
-  checked={{this.value}}
+  @checked={{this.value}}
 />
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
@@ -23,7 +23,7 @@
         @value={{option.label}}
         @onChange={{fn this.updateValue option}}
         @disabled={{@show}}
-        checked={{option.provided}}
+        @checked={{option.provided}}
       />
     </div>
   {{/each}}

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
@@ -7,7 +7,7 @@
     @label="Vink aan indien er sprake is van differentiatie"
     @onChange={{this.toggleDifferentiatie}}
     @disabled={{@show}}
-    checked={{this.differentiatie}}
+    @checked={{this.differentiatie}}
   />
 {{else}}
   <AuHelpText>


### PR DESCRIPTION
`AuControlCheckbox` uses the `Input` component internally which requires `checked` to be passed as an argument instead of an attribute.

Fixes #67 