### PR TITLE
Fix a problem where number input fields were displayed as text input fields

### DIFF
--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.hbs
@@ -8,7 +8,7 @@
       @width="block"
       @value={{this.costPerUnit}}
       @error={{if this.costPerUnitErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />
@@ -25,7 +25,7 @@
       @width="block"
       @value={{this.toRealiseUnits}}
       @error={{if this.toRealiseUnitsErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-custom-action.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-custom-action.hbs
@@ -26,7 +26,7 @@
       @width="block"
       @value={{this.costPerUnit}}
       @error={{if this.costPerUnitErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />
@@ -40,7 +40,7 @@
       @width="block"
       @value={{this.toRealiseUnits}}
       @error={{if this.toRealiseUnitsErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.hbs
@@ -8,7 +8,7 @@
       @width="block"
       @value={{this.costPerUnit}}
       @error={{if this.costPerUnitErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />
@@ -25,7 +25,7 @@
       @width="block"
       @value={{this.toRealiseUnits}}
       @error={{if this.toRealiseUnitsErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.hbs
@@ -8,7 +8,7 @@
       @width="block"
       @value={{this.costPerUnit}}
       @error={{if this.costPerUnitErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />
@@ -23,7 +23,7 @@
       @width="block"
       @value={{this.toRealiseUnits}}
       @error={{if this.toRealiseUnitsErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />

--- a/addon/components/custom-subsidy-form-fields/engagement-table/edit.hbs
+++ b/addon/components/custom-subsidy-form-fields/engagement-table/edit.hbs
@@ -26,7 +26,7 @@
             Bestaand personeelskader
           </AuLabel>
           <AuInput id="existing-staff-{{index}}" @width="block" @value={{entry.existingStaff.value}}
-            type="number"
+            @type="number"
             class={{if entry.existingStaff.errors "au-c-input--error"}}
             {{on "change" (fn this.updateExistingStaffValue entry)}}
           />
@@ -39,7 +39,7 @@
             (Tijdelijk) extra aangeworven betaald personeel
           </AuLabel>
           <AuInput id="additional-staff-{{index}}" @width="block" @value={{entry.additionalStaff.value}}
-            type="number"
+            @type="number"
             class={{if entry.additionalStaff.errors "au-c-input--error"}}
             {{on "change" (fn this.updateAdditionalStaffValue entry)}}
           />
@@ -52,7 +52,7 @@
             Vrijwilligers
           </AuLabel>
           <AuInput id="volunteers-{{index}}" @width="block" @value={{entry.volunteers.value}}
-            type="number"
+            @type="number"
             class={{if entry.volunteers.errors "au-c-input--error"}}
             {{on "change" (fn this.updateVolunteersValue entry)}}
           />

--- a/addon/components/custom-subsidy-form-fields/engagement-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/engagement-table/show.hbs
@@ -28,19 +28,19 @@
           <AuLabel for="existing-staff-{{index}}" class="au-u-hidden-visually">
             Bestaand personeelskader
           </AuLabel>
-          <AuInput id="existing-staff-{{index}}" @width="block" @value={{entry.existingStaff.value}} @disabled={{true}} type="number"/>
+          <AuInput id="existing-staff-{{index}}" @width="block" @value={{entry.existingStaff.value}} @disabled={{true}} @type="number"/>
         </td>
         <td>
           <AuLabel for="additional-staff-{{index}}" class="au-u-hidden-visually">
             (Tijdelijk) extra aangeworven betaald personeel
           </AuLabel>
-          <AuInput id="additional-staff-{{index}}" @width="block" @value={{entry.additionalStaff.value}} @disabled={{true}} type="number"/>
+          <AuInput id="additional-staff-{{index}}" @width="block" @value={{entry.additionalStaff.value}} @disabled={{true}} @type="number"/>
         </td>
         <td>
           <AuLabel for="volunteers-{{index}}" class="au-u-hidden-visually">
             Vrijwilligers
           </AuLabel>
-          <AuInput id="volunteers-{{index}}" @width="block" @value={{entry.volunteers.value}} @disabled={{true}} type="number"/>
+          <AuInput id="volunteers-{{index}}" @width="block" @value={{entry.volunteers.value}} @disabled={{true}} @type="number"/>
         </td>
       </tr>
     {{/each}}

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.hbs
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.hbs
@@ -31,7 +31,7 @@
             Kosten (Excl. BTW)
           </AuLabel>
           <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}}
-            type="number"
+            @type="number"
             class={{if entry.cost.errors "au-c-input--error"}}
             {{on "blur" (fn this.updateCost entry)}}
           />
@@ -44,7 +44,7 @@
             Het gemeentelijk aandeel (%) in kosten
           </AuLabel>
           <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}}
-            type="number"
+            @type="number"
             class={{if entry.share.errors "au-c-input--error"}}
             {{on "blur" (fn this.updateShare entry)}}
           />

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/show.hbs
@@ -29,7 +29,7 @@
             Kosten (Excl. BTW)
           </AuLabel>
           <AuInput id="costs-{{index}}" @width="block" step="any" @value={{entry.cost.value}} @disabled={{true}}
-            type="number"
+            @type="number"
           />
         </td>
         <td>
@@ -37,7 +37,7 @@
             Het gemeentelijk aandeel (%) in kosten
           </AuLabel>
           <AuInput id="share-{{index}}" @width="block" step="any" @value={{entry.share.value}} @disabled={{true}}
-            type="number"
+            @type="number"
           />
         </td>
       </tr>

--- a/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
+++ b/addon/components/custom-subsidy-form-fields/objective-table/table-cell.hbs
@@ -1,7 +1,7 @@
 <td headers={{@tableHeaders}}>
   <AuInput
     @disabled={{@disabled}}
-    type="number"
+    @type="number"
     lang="nl-BE"
     @width="block"
     @value={{this.kilometers}}

--- a/addon/components/custom-subsidy-form-fields/plan-living-together-table/table-row.hbs
+++ b/addon/components/custom-subsidy-form-fields/plan-living-together-table/table-row.hbs
@@ -8,7 +8,7 @@
       @width="block"
       @value={{this.currentRange}}
       @error={{if this.currentRangeErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />
@@ -24,7 +24,7 @@
       @width="block"
       @value={{this.plannedRange}}
       @error={{if this.plannedRangeErrors true false}}
-      type="number"
+      @type="number"
       lang="nl-BE"
       {{on "blur" this.update}}
     />

--- a/addon/components/rdf-input-fields/date-time.hbs
+++ b/addon/components/rdf-input-fields/date-time.hbs
@@ -45,7 +45,7 @@
                    @type="number"
                    @min="0"
                    @max="23"
-                   type="number"
+                   @type="number"
             {{on "blur" this.updateValue}} />
         </div>
         <div class="au-o-grid__item au-u-1-2">
@@ -62,7 +62,7 @@
                    @type="number"
                    @min="0"
                    @max="59"
-                   type="number"
+                   @type="number"
             {{on "blur" this.updateValue}} />
         </div>
       </div>

--- a/addon/components/rdf-input-fields/numerical-input.hbs
+++ b/addon/components/rdf-input-fields/numerical-input.hbs
@@ -9,7 +9,7 @@
   @error={{this.hasErrors}}
   @value={{this.value}}
   @disabled={{@show}}
-  type="number"
+  @type="number"
   id={{this.inputId}}
   lang="nl-BE"
   {{on "change" this.updateValue}}

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "uuid": "^7.0.3"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.0",
+    "@appuniversum/ember-appuniversum": "^1.0.6",
     "ember-data": "^3.16.0 || ^4.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.0",
+    "@appuniversum/ember-appuniversum": "^1.0.6",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@embroider/test-setup": "^1.0.0",


### PR DESCRIPTION
Ember's Input component requires that it's passed as an argument. This should fix the problem where number inputs were marked as regular inputs.