### PR TITLE
Resolve `AuAlert` deprecation warnings

### DIFF
--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -11,10 +11,10 @@
         {{/if}}
         {{#each this.errors as |error|}}
           <AuAlert class="au-u-margin-bottom-small au-u-margin-top-small"
-                   @alertIcon="alert-triangle"
-                   @alertTitle={{error.resultMessage}}
-                   @alertskin={{"error"}}
-                   @alertsize={{"small"}}>
+                   @icon="alert-triangle"
+                   @title={{error.resultMessage}}
+                   @skin="error"
+                   @size="small">
           </AuAlert>
         {{/each}}
       </div>

--- a/addon/components/rdf-input-fields/case-number.hbs
+++ b/addon/components/rdf-input-fields/case-number.hbs
@@ -1,10 +1,10 @@
 <AuLabel for={{this.id}}>{{@field.label}}</AuLabel>
-{{#if this.showAlert}}
+{{#if true}}
   <AuAlert
-    @alertIcon="alert-triangle"
-    @alertTitle="Oeps, dit is een beetje gênant!"
-    @alertskin={{"warning"}}
-    @alertsize={{"small"}}
+    @icon="alert-triangle"
+    @title="Oeps, dit is een beetje gênant!"
+    @skin="warning"
+    @size="small"
     @closable={{true}}
     class="au-u-margin-bottom-small"
   >

--- a/addon/components/rdf-input-fields/remote-urls/show.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/show.hbs
@@ -45,9 +45,9 @@
 
 {{#if this.hasRemoteUrlErrors}}
   <AuAlert
-    @alertSkin="error"
-    @alertIcon="info-circle"
-    @alertSize="small"
+    @skin="error"
+    @icon="info-circle"
+    @size="small"
   >
     Er ging iets fout bij het ophalen van de addressen.
   </AuAlert>

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -1,9 +1,9 @@
 {{#unless @show}}
   <AuAlert
-    @alertIcon="info-circle"
-    @alertTitle="Gelieve per besluit of besluitenlijst één dossier aan te maken."
-    @alertskin={{"info"}}
-    @alertsize="small" />
+    @icon="info-circle"
+    @title="Gelieve per besluit of besluitenlijst één dossier aan te maken."
+    @skin="info"
+    @size="small" />
 {{/unless}}
 <div class="au-c-form">
   <ul class="au-o-grid au-o-grid--small">

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "uuid": "^7.0.3"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.6",
+    "@appuniversum/ember-appuniversum": "^1.0.9",
     "ember-data": "^3.16.0 || ^4.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.0.6",
+    "@appuniversum/ember-appuniversum": "^1.0.9",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@embroider/test-setup": "^1.0.0",


### PR DESCRIPTION
The `alert*` prefixed argument names were deprecated in v1.0.8.