### PR TITLE
Fix the problem where the case-number error message was always shown

### DIFF
--- a/addon/components/rdf-input-fields/case-number.hbs
+++ b/addon/components/rdf-input-fields/case-number.hbs
@@ -1,5 +1,5 @@
 <AuLabel for={{this.id}}>{{@field.label}}</AuLabel>
-{{#if true}}
+{{#if this.showAlert}}
   <AuAlert
     @icon="alert-triangle"
     @title="Oeps, dit is een beetje gênant!"


### PR DESCRIPTION
It seems this sneaked into the last [PR](https://github.com/lblod/ember-submission-form-fields/pull/73) by accident and causes the error message to always be shown, even if the value is valid.