### PR TITLE
Add language string support

### DIFF
--- a/addon/components/rdf-input-fields/simple-value-input-field.js
+++ b/addon/components/rdf-input-fields/simple-value-input-field.js
@@ -3,6 +3,7 @@ import InputFieldComponent from './input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { updateSimpleFormValue } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
+import rdflib from 'browser-rdflib';
 
 export default class SimpleValueInputFieldComponent extends InputFieldComponent {
   @tracked value = null;
@@ -15,10 +16,24 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
 
   loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);
+
     if (matches.values.length > 0) {
-      this.nodeValue = matches.values[0];
-      this.value = matches.values[0].value;
-    } else if (this.defaultValue && this.value == null) {
+      let literal = findLiteralByLanguage(
+        matches.values,
+        this.args.field.language
+      );
+
+      if (literal) {
+        this.nodeValue = literal;
+        this.value = literal.value;
+      }
+    }
+
+    if (!this.nodeValue && this.args.field.language) {
+      this.nodeValue = new rdflib.Literal('', this.args.field.language);
+    }
+
+    if (this.defaultValue && this.value == null) {
       this.value = this.defaultValue;
       next(this, () => {
         this.updateValue();
@@ -27,9 +42,32 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
   }
 
   updateValue(value) {
-    updateSimpleFormValue(this.storeOptions, value, this.nodeValue);
+    let literalOrValue;
+
+    if (rdflib.isLiteral(value)) {
+      literalOrValue = value;
+    } else {
+      literalOrValue = this.nodeValue?.copy();
+      if (literalOrValue) {
+        literalOrValue.value = value;
+      } else {
+        literalOrValue = value;
+      }
+    }
+
+    updateSimpleFormValue(this.storeOptions, literalOrValue, this.nodeValue);
     this.hasBeenFocused = true;
     this.loadProvidedValue();
     super.updateValidations();
   }
+}
+
+/**
+ *
+ * @param {{}[]} literals Array of Literal instances
+ * @param {string} [language] language tag of the literal. If left empty the literal without a language tag will be returned
+ * @returns literal instance
+ */
+function findLiteralByLanguage(literals = [], language = '') {
+  return literals.find((literal) => literal.language === language);
 }

--- a/addon/models/field.js
+++ b/addon/models/field.js
@@ -34,6 +34,14 @@ export default class FieldModel {
       undefined,
       formGraph
     );
+
+    this.rdflibLanguage = store.any(
+      uri,
+      FORM('language'),
+      undefined,
+      formGraph
+    );
+
     if (this.rdflibPath) {
       // this.rdflibValue = store.any(sourceNode, this.rdflibPath, undefined, sourceGraph);
     }
@@ -99,5 +107,9 @@ export default class FieldModel {
   rdflibDefaultValue = null;
   get defaultValue() {
     return this.rdflibDefaultValue && this.rdflibDefaultValue.value;
+  }
+
+  get language() {
+    return this.rdflibLanguage?.value;
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -46,6 +46,12 @@
                 </AuNavigationLink>
               </li>
 
+              <li class="au-c-list-navigation__item">
+                <AuNavigationLink @route="form" @model="lang-strings">
+                  Language string support
+                </AuNavigationLink>
+              </li>
+
               <li
                 class="au-c-list-navigation__item au-c-list-navigation__item--section"
               >

--- a/tests/dummy/app/templates/form.hbs
+++ b/tests/dummy/app/templates/form.hbs
@@ -28,7 +28,15 @@
     <tr>
       <td>{{triple.subject}}</td>
       <td>{{triple.predicate}}</td>
-      <td>{{triple.object}}</td>
+      <td>{{triple.object}}
+        {{#if (eq triple.object.datatype.value "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")}}
+          @{{triple.object.language}}
+        {{else}}
+          {{#if triple.object.datatype.value}}
+            ^^{{triple.object.datatype}}
+          {{/if}}
+        {{/if}}
+      </td>
     </tr>
   {{/each}}
   </:body>

--- a/tests/dummy/public/test-forms/lang-strings/data.ttl
+++ b/tests/dummy/public/test-forms/lang-strings/data.ttl
@@ -1,0 +1,5 @@
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+<http://ember-submission-form-fields/source-node> ext:title "Foo".
+<http://ember-submission-form-fields/source-node> ext:title "Bar"@nl.
+<http://ember-submission-form-fields/source-node> ext:title "Baz"@en.

--- a/tests/dummy/public/test-forms/lang-strings/form.ttl
+++ b/tests/dummy/public/test-forms/lang-strings/form.ttl
@@ -1,0 +1,50 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix schema: <http://schema.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+##########################################################
+# form
+##########################################################
+ext:mainFg a form:FieldGroup.
+
+ext:form a form:Form, form:TopLevelForm ;
+    form:includes ext:input;
+    form:includes ext:inputNL;
+    form:includes ext:inputEN.
+
+##########################################################
+#  Listing property-group
+##########################################################
+ext:mainPg a form:PropertyGroup;
+    sh:order 1 .
+
+##########################################################
+# Field
+##########################################################
+ext:input a form:Field ;
+    sh:name "Title" ;
+    sh:order 10 ;
+    sh:path ext:title ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:mainPg .
+
+ext:inputNL a form:Field ;
+    sh:name "Title (NL)" ;
+    sh:order 10 ;
+    sh:path ext:title ;
+    form:displayType displayTypes:defaultInput ;
+    form:language "nl";
+    sh:group ext:mainPg .
+
+ext:inputEN a form:Field ;
+    sh:name "Title (EN)" ;
+    sh:order 10 ;
+    sh:path ext:title ;
+    form:displayType displayTypes:defaultInput ;
+    form:language "en";
+    sh:group ext:mainPg .


### PR DESCRIPTION
Fields can now configure a language and the correct language-tagged literal will be retrieved from the graph. If no language is configured, the literal without a language tag is returned instead.