### PR TITLE
Ensure to provide nodeValue only when literal is found for langStr

### DIFF
--- a/addon/components/rdf-input-fields/simple-value-input-field.js
+++ b/addon/components/rdf-input-fields/simple-value-input-field.js
@@ -40,8 +40,11 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
           literal = literals[0];
         }
       }
-      this.nodeValue = literal;
-      this.value = literal.value;
+
+      if(literal) {
+        this.nodeValue = literal;
+        this.value = literal.value;
+      }
     }
 
     if (!this.nodeValue && this.args.field.language) {


### PR DESCRIPTION
I introduced a bug in latest updates langstring. This PR fixes it. FYI @Windvis 