### PR TITLE
Replace browser-rdflib with rdflib v2

### DIFF
--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
@@ -7,7 +7,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { SKOS } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { namedNode, Namespace } from 'rdflib';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -30,7 +30,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorEditCompone
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
@@ -139,12 +139,8 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorEditCompone
   }
 
   getPathToOrgaanClassification(bestuursorgaanInTimeUri, graph) {
-    const MANDAAT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/mandaat#'
-    );
-    const BESLUIT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/besluit#'
-    );
+    const MANDAAT = new Namespace('http://data.vlaanderen.be/ns/mandaat#');
+    const BESLUIT = new Namespace('http://data.vlaanderen.be/ns/besluit#');
 
     const bestuursorgaan = this.args.formStore.match(
       bestuursorgaanInTimeUri,
@@ -167,9 +163,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorEditCompone
   }
 
   getPathToEenheidClassification(bestuursorgaanUri, graph) {
-    const BESLUIT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/besluit#'
-    );
+    const BESLUIT = new Namespace('http://data.vlaanderen.be/ns/besluit#');
 
     const bestuurseenheid = this.args.formStore.match(
       bestuursorgaanUri,

--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
@@ -3,8 +3,8 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { SKOS } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { next } from '@ember/runloop';
+import { namedNode, Namespace } from 'rdflib';
 
 export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -26,7 +26,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowCompone
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
@@ -95,12 +95,8 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowCompone
   }
 
   getPathToOrgaanClassification(bestuursorgaanInTimeUri, graph) {
-    const MANDAAT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/mandaat#'
-    );
-    const BESLUIT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/besluit#'
-    );
+    const MANDAAT = new Namespace('http://data.vlaanderen.be/ns/mandaat#');
+    const BESLUIT = new Namespace('http://data.vlaanderen.be/ns/besluit#');
 
     const bestuursorgaan = this.args.formStore.match(
       bestuursorgaanInTimeUri,
@@ -123,9 +119,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowCompone
   }
 
   getPathToEenheidClassification(bestuursorgaanUri, graph) {
-    const BESLUIT = new rdflib.Namespace(
-      'http://data.vlaanderen.be/ns/besluit#'
-    );
+    const BESLUIT = new Namespace('http://data.vlaanderen.be/ns/besluit#');
 
     const bestuurseenheid = this.args.formStore.match(
       bestuursorgaanUri,

--- a/addon/components/custom-subsidy-form-fields/application-form-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/application-form-table/edit.js
@@ -2,13 +2,13 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath, XSD } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const applicationFormTableBaseUri =
   'http://data.lblod.info/application-form-tables';
@@ -17,38 +17,36 @@ const applicationFormEntryBaseUri =
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
 const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
 
-const ApplicationFormTableType = new rdflib.NamedNode(
+const ApplicationFormTableType = new NamedNode(
   `${lblodSubsidieBaseUri}ApplicationFormTable`
 );
-const ApplicationFormEntryType = new rdflib.NamedNode(
+const ApplicationFormEntryType = new NamedNode(
   `${extBaseUri}ApplicationFormEntry`
 );
-const applicationFormTablePredicate = new rdflib.NamedNode(
+const applicationFormTablePredicate = new NamedNode(
   `${lblodSubsidieBaseUri}applicationFormTable`
 );
-const applicationFormEntryPredicate = new rdflib.NamedNode(
+const applicationFormEntryPredicate = new NamedNode(
   `${extBaseUri}applicationFormEntry`
 );
-const actorNamePredicate = new rdflib.NamedNode(
+const actorNamePredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/actorName'
 );
-const numberChildrenForFullDayPredicate = new rdflib.NamedNode(
+const numberChildrenForFullDayPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay'
 );
-const numberChildrenForHalfDayPredicate = new rdflib.NamedNode(
+const numberChildrenForHalfDayPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay'
 );
-const numberChildrenPerInfrastructurePredicate = new rdflib.NamedNode(
+const numberChildrenPerInfrastructurePredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure'
 );
-const totalAmountPredicate = new rdflib.NamedNode(
+const totalAmountPredicate = new NamedNode(
   'http://lblod.data.gift/vocabularies/subsidie/totalAmount'
 );
-const createdPredicate = new rdflib.NamedNode(
-  'http://purl.org/dc/terms/created'
-);
+const createdPredicate = new NamedNode('http://purl.org/dc/terms/created');
 
-const LBLOD_SUBSIDIE = new rdflib.Namespace(
+const LBLOD_SUBSIDIE = new Namespace(
   'http://lblod.data.gift/vocabularies/subsidie/'
 );
 
@@ -306,7 +304,7 @@ export default class CustomSubsidyFormFieldsApplicationFormTableEditComponent ex
 
   createApplicationFormTable() {
     const uuid = uuidv4();
-    this.applicationFormTableSubject = new rdflib.NamedNode(
+    this.applicationFormTableSubject = new NamedNode(
       `${applicationFormTableBaseUri}/${uuid}`
     );
     const triples = [
@@ -334,7 +332,7 @@ export default class CustomSubsidyFormFieldsApplicationFormTableEditComponent ex
 
   createApplicationFormEntry() {
     const uuid = uuidv4();
-    const applicationFormEntrySubject = new rdflib.NamedNode(
+    const applicationFormEntrySubject = new NamedNode(
       `${applicationFormEntryBaseUri}/${uuid}`
     );
     const triples = [
@@ -441,7 +439,7 @@ export default class CustomSubsidyFormFieldsApplicationFormTableEditComponent ex
       {
         subject: this.storeOptions.sourceNode,
         predicate: totalAmountPredicate,
-        object: rdflib.literal(
+        object: literal(
           Number.parseFloat(this.totalAmount).toFixed(2),
           XSD('float')
         ),

--- a/addon/components/custom-subsidy-form-fields/application-form-table/show.js
+++ b/addon/components/custom-subsidy-form-fields/application-form-table/show.js
@@ -1,30 +1,28 @@
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 
 const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
 
-const applicationFormEntryPredicate = new rdflib.NamedNode(
+const applicationFormEntryPredicate = new NamedNode(
   `${extBaseUri}applicationFormEntry`
 );
-const actorNamePredicate = new rdflib.NamedNode(
+const actorNamePredicate = new NamedNode(
   `http://mu.semte.ch/vocabularies/ext/actorName`
 );
-const numberChildrenForFullDayPredicate = new rdflib.NamedNode(
+const numberChildrenForFullDayPredicate = new NamedNode(
   `http://mu.semte.ch/vocabularies/ext/numberChildrenForFullDay`
 );
-const numberChildrenForHalfDayPredicate = new rdflib.NamedNode(
+const numberChildrenForHalfDayPredicate = new NamedNode(
   `http://mu.semte.ch/vocabularies/ext/numberChildrenForHalfDay`
 );
-const numberChildrenPerInfrastructurePredicate = new rdflib.NamedNode(
+const numberChildrenPerInfrastructurePredicate = new NamedNode(
   `http://mu.semte.ch/vocabularies/ext/numberChildrenPerInfrastructure`
 );
-const createdPredicate = new rdflib.NamedNode(
-  'http://purl.org/dc/terms/created'
-);
+const createdPredicate = new NamedNode('http://purl.org/dc/terms/created');
 
-const LBLOD_SUBSIDIE = new rdflib.Namespace(
+const LBLOD_SUBSIDIE = new Namespace(
   'http://lblod.data.gift/vocabularies/subsidie/'
 );
 

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table.js
@@ -4,41 +4,35 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
+import { NamedNode, Namespace } from 'rdflib';
 import { RDF } from '@lblod/submission-form-helpers';
 
-const LBLOD_SUBSIDIE = new rdflib.Namespace(
+const LBLOD_SUBSIDIE = new Namespace(
   'http://lblod.data.gift/vocabularies/subsidie/'
 );
-const DBPEDIA = new rdflib.Namespace('http://dbpedia.org/ontology/');
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const DBPEDIA = new Namespace('http://dbpedia.org/ontology/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 
-const climateTableType = new rdflib.NamedNode(
-  `${lblodSubsidieBaseUri}ClimateTable`
-);
-const climateTablePredicate = new rdflib.NamedNode(
+const climateTableType = new NamedNode(`${lblodSubsidieBaseUri}ClimateTable`);
+const climateTablePredicate = new NamedNode(
   `${lblodSubsidieBaseUri}climateTable`
 );
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const hasInvalidRowPredicate = new NamedNode(
   `${climateTableBaseUri}/hasInvalidClimateTableEntry`
 );
-const validClimateTable = new rdflib.NamedNode(
+const validClimateTable = new NamedNode(
   `${lblodSubsidieBaseUri}validClimateTable`
 );
-const totalBudgettedAmount = new rdflib.NamedNode(
+const totalBudgettedAmount = new NamedNode(
   `${lblodSubsidieBaseUri}totalBudgettedAmount`
 );
-const allowNewActions = new rdflib.NamedNode(
-  `${climateTableBaseUri}/allowNewActions`
-);
-const climateEntryCustomAction = new rdflib.NamedNode(
-  `${climateBaseUri}customAction`
-);
+const allowNewActions = new NamedNode(`${climateTableBaseUri}/allowNewActions`);
+const climateEntryCustomAction = new NamedNode(`${climateBaseUri}customAction`);
 
 /*
  * Component wrapping the big subsidy table for climate action.
@@ -182,9 +176,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableComponent ex
 
   createClimateTable() {
     const uuid = uuidv4();
-    this.climateTableSubject = new rdflib.NamedNode(
-      `${climateTableBaseUri}/${uuid}`
-    );
+    this.climateTableSubject = new NamedNode(`${climateTableBaseUri}/${uuid}`);
     const triples = [
       {
         subject: this.climateTableSubject,
@@ -291,7 +283,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableComponent ex
     this.customActions = [
       ...this.customActions,
       {
-        businessRuleUri: new rdflib.NamedNode(
+        businessRuleUri: new NamedNode(
           `http://data.lblod.info/id/subsidies/rules/custom/${uuid}`
         ),
         order: highestOrderValue + 1,

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-burgemeesters.js
@@ -1,40 +1,34 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import rdflib from 'browser-rdflib';
 import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '@lblod/submission-form-helpers';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 
 const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
-const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
-const climateEntryPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}climateEntry`
-);
-const actionDescriptionPredicate = new rdflib.NamedNode(
+const ClimateEntryType = new NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new NamedNode(`${climateBaseUri}climateEntry`);
+const actionDescriptionPredicate = new NamedNode(
   `${climateBaseUri}actionDescription`
 );
-const amountPerActionPredicate = new rdflib.NamedNode(
+const amountPerActionPredicate = new NamedNode(
   `${climateBaseUri}amountPerAction`
 );
-const restitutionPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}restitution`
-);
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const restitutionPredicate = new NamedNode(`${climateBaseUri}restitution`);
+const hasInvalidRowPredicate = new NamedNode(
   `${climateTableBaseUri}/hasInvalidClimateTableEntry`
 );
-const toRealiseUnitsPredicate = new rdflib.NamedNode(
+const toRealiseUnitsPredicate = new NamedNode(
   `${climateBaseUri}toRealiseUnits`
 );
-const costPerUnitPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}costPerUnit`
-);
+const costPerUnitPredicate = new NamedNode(`${climateBaseUri}costPerUnit`);
 
 export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowBurgemeestersComponent extends Component {
   @tracked tableEntryUri = null;
@@ -55,7 +49,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowBurg
   }
 
   get businessRuleUri() {
-    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+    return new NamedNode(this.args.businessRuleUriStr);
   }
 
   get onUpdateRow() {
@@ -118,7 +112,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowBurg
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+    const tableEntryUri = new NamedNode(`${tableEntryBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -316,22 +310,22 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowBurg
     this.updateTripleObject(
       this.tableEntryUri,
       toRealiseUnitsPredicate,
-      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+      literal(this.toRealiseUnits, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       amountPerActionPredicate,
-      rdflib.literal(amount, XSD('integer'))
+      literal(amount, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       restitutionPredicate,
-      rdflib.literal(newRestitution, XSD('float'))
+      literal(newRestitution, XSD('float'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       costPerUnitPredicate,
-      rdflib.literal(this.costPerUnit, XSD('float'))
+      literal(this.costPerUnit, XSD('float'))
     );
     this.setComponentValues(this.tableEntryUri);
 

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-custom-action.js
@@ -1,10 +1,10 @@
 import Component from '@glimmer/component';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { scheduleOnce } from '@ember/runloop';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
 import {
   RDF,
@@ -12,41 +12,33 @@ import {
   removeSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
-const QB = new rdflib.Namespace('http://purl.org/linked-data/cube#');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
+const QB = new Namespace('http://purl.org/linked-data/cube#');
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 
 const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
-const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
-const climateEntryPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}climateEntry`
-);
-const climateEntryCustomAction = new rdflib.NamedNode(
-  `${climateBaseUri}customAction`
-);
-const actionDescriptionPredicate = new rdflib.NamedNode(
+const ClimateEntryType = new NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new NamedNode(`${climateBaseUri}climateEntry`);
+const climateEntryCustomAction = new NamedNode(`${climateBaseUri}customAction`);
+const actionDescriptionPredicate = new NamedNode(
   `${climateBaseUri}actionDescription`
 );
-const amountPerActionPredicate = new rdflib.NamedNode(
+const amountPerActionPredicate = new NamedNode(
   `${climateBaseUri}amountPerAction`
 );
-const restitutionPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}restitution`
-);
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const restitutionPredicate = new NamedNode(`${climateBaseUri}restitution`);
+const hasInvalidRowPredicate = new NamedNode(
   `${climateTableBaseUri}/hasInvalidClimateTableEntry`
 );
-const customDescriptionPredicate = new rdflib.NamedNode(
+const customDescriptionPredicate = new NamedNode(
   `${climateBaseUri}customDescription`
 );
-const toRealiseUnitsPredicate = new rdflib.NamedNode(
+const toRealiseUnitsPredicate = new NamedNode(
   `${climateBaseUri}toRealiseUnits`
 );
-const costPerUnitPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}costPerUnit`
-);
+const costPerUnitPredicate = new NamedNode(`${climateBaseUri}costPerUnit`);
 
 export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowCustomDataComponent extends Component {
   id = guidFor(this);
@@ -147,7 +139,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowCust
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+    const tableEntryUri = new NamedNode(`${tableEntryBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -270,27 +262,27 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowCust
       this.updateTripleObject(
         this.tableEntryUri,
         customDescriptionPredicate,
-        rdflib.literal(this.description.trim())
+        literal(this.description.trim())
       );
       this.updateTripleObject(
         this.tableEntryUri,
         toRealiseUnitsPredicate,
-        rdflib.literal(this.toRealiseUnits, XSD('integer'))
+        literal(this.toRealiseUnits, XSD('integer'))
       );
       this.updateTripleObject(
         this.tableEntryUri,
         amountPerActionPredicate,
-        rdflib.literal(amount, XSD('integer'))
+        literal(amount, XSD('integer'))
       );
       this.updateTripleObject(
         this.tableEntryUri,
         restitutionPredicate,
-        rdflib.literal(newRestitution, XSD('float'))
+        literal(newRestitution, XSD('float'))
       );
       this.updateTripleObject(
         this.tableEntryUri,
         costPerUnitPredicate,
-        rdflib.literal(this.costPerUnit, XSD('float'))
+        literal(this.costPerUnit, XSD('float'))
       );
       this.setComponentValues(this.tableEntryUri);
 

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-vastgoedplan.js
@@ -1,39 +1,33 @@
 import Component from '@glimmer/component';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { A } from '@ember/array';
 import { scheduleOnce } from '@ember/runloop';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
 import { RDF, XSD } from '@lblod/submission-form-helpers';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 
 const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
-const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
-const climateEntryPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}climateEntry`
-);
-const actionDescriptionPredicate = new rdflib.NamedNode(
+const ClimateEntryType = new NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new NamedNode(`${climateBaseUri}climateEntry`);
+const actionDescriptionPredicate = new NamedNode(
   `${climateBaseUri}actionDescription`
 );
-const amountPerActionPredicate = new rdflib.NamedNode(
+const amountPerActionPredicate = new NamedNode(
   `${climateBaseUri}amountPerAction`
 );
-const costPerUnitPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}costPerUnit`
-);
-const restitutionPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}restitution`
-);
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const costPerUnitPredicate = new NamedNode(`${climateBaseUri}costPerUnit`);
+const restitutionPredicate = new NamedNode(`${climateBaseUri}restitution`);
+const hasInvalidRowPredicate = new NamedNode(
   `${climateTableBaseUri}/hasInvalidClimateTableEntry`
 );
-const toRealiseUnitsPredicate = new rdflib.NamedNode(
+const toRealiseUnitsPredicate = new NamedNode(
   `${climateBaseUri}toRealiseUnits`
 );
 
@@ -56,7 +50,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowVast
   }
 
   get businessRuleUri() {
-    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+    return new NamedNode(this.args.businessRuleUriStr);
   }
 
   get climateTableSubject() {
@@ -146,7 +140,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowVast
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+    const tableEntryUri = new NamedNode(`${tableEntryBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -315,22 +309,22 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowVast
     this.updateTripleObject(
       this.tableEntryUri,
       toRealiseUnitsPredicate,
-      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+      literal(this.toRealiseUnits, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       amountPerActionPredicate,
-      rdflib.literal(amount, XSD('integer'))
+      literal(amount, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       restitutionPredicate,
-      rdflib.literal(newRestitution, XSD('float'))
+      literal(newRestitution, XSD('float'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       costPerUnitPredicate,
-      rdflib.literal(this.costPerUnit, XSD('float'))
+      literal(this.costPerUnit, XSD('float'))
     );
     this.setComponentValues(this.tableEntryUri);
 

--- a/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.js
+++ b/addon/components/custom-subsidy-form-fields/climate-subsidy-costs-table/table-row-werf.js
@@ -1,41 +1,35 @@
 import Component from '@glimmer/component';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
 import { RDF, XSD } from '@lblod/submission-form-helpers';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const climateBaseUri = 'http://data.lblod.info/vocabularies/subsidie/climate/';
 const climateTableBaseUri = 'http://data.lblod.info/climate-tables';
 
 const tableEntryBaseUri = 'http://data.lblod.info/id/climate-table/row-entry';
-const ClimateEntryType = new rdflib.NamedNode(`${climateBaseUri}ClimateEntry`);
-const climateEntryPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}climateEntry`
-);
-const actionDescriptionPredicate = new rdflib.NamedNode(
+const ClimateEntryType = new NamedNode(`${climateBaseUri}ClimateEntry`);
+const climateEntryPredicate = new NamedNode(`${climateBaseUri}climateEntry`);
+const actionDescriptionPredicate = new NamedNode(
   `${climateBaseUri}actionDescription`
 );
-const amountPerActionPredicate = new rdflib.NamedNode(
+const amountPerActionPredicate = new NamedNode(
   `${climateBaseUri}amountPerAction`
 );
-const restitutionPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}restitution`
-);
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const restitutionPredicate = new NamedNode(`${climateBaseUri}restitution`);
+const hasInvalidRowPredicate = new NamedNode(
   `${climateTableBaseUri}/hasInvalidClimateTableEntry`
 );
-const toRealiseUnitsPredicate = new rdflib.NamedNode(
+const toRealiseUnitsPredicate = new NamedNode(
   `${climateBaseUri}toRealiseUnits`
 );
-const costPerUnitPredicate = new rdflib.NamedNode(
-  `${climateBaseUri}costPerUnit`
-);
+const costPerUnitPredicate = new NamedNode(`${climateBaseUri}costPerUnit`);
 
 export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowWerfComponent extends Component {
   @tracked tableEntryUri = null;
@@ -52,7 +46,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowWerf
   }
 
   get businessRuleUri() {
-    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+    return new NamedNode(this.args.businessRuleUriStr);
   }
 
   get climateTableSubject() {
@@ -132,7 +126,7 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowWerf
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+    const tableEntryUri = new NamedNode(`${tableEntryBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -309,22 +303,22 @@ export default class CustomSubsidyFormFieldsClimateSubsidyCostsTableTableRowWerf
     this.updateTripleObject(
       this.tableEntryUri,
       toRealiseUnitsPredicate,
-      rdflib.literal(this.toRealiseUnits, XSD('integer'))
+      literal(this.toRealiseUnits, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       amountPerActionPredicate,
-      rdflib.literal(amount, XSD('integer'))
+      literal(amount, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       restitutionPredicate,
-      rdflib.literal(newRestitution, XSD('float'))
+      literal(newRestitution, XSD('float'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       costPerUnitPredicate,
-      rdflib.literal(this.costPerUnit, XSD('float'))
+      literal(this.costPerUnit, XSD('float'))
     );
     this.setComponentValues(this.tableEntryUri);
 

--- a/addon/components/custom-subsidy-form-fields/engagement-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/engagement-table/edit.js
@@ -2,37 +2,33 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
+import { NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const engagementTableBaseUri = 'http://data.lblod.info/engagement-tables';
 const engagementEntryBaseUri = 'http://data.lblod.info/engagement-entries';
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
 const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
 
-const EngagementTableType = new rdflib.NamedNode(
+const EngagementTableType = new NamedNode(
   `${lblodSubsidieBaseUri}EngagementTable`
 );
-const EngagementEntryType = new rdflib.NamedNode(
-  `${extBaseUri}EngagementEntry`
-);
-const engagementTablePredicate = new rdflib.NamedNode(
+const EngagementEntryType = new NamedNode(`${extBaseUri}EngagementEntry`);
+const engagementTablePredicate = new NamedNode(
   `${lblodSubsidieBaseUri}engagementTable`
 );
-const engagementEntryPredicate = new rdflib.NamedNode(
-  `${extBaseUri}engagementEntry`
-);
-const existingStaffPredicate = new rdflib.NamedNode(
+const engagementEntryPredicate = new NamedNode(`${extBaseUri}engagementEntry`);
+const existingStaffPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/existingStaff'
 );
-const additionalStaffPredicate = new rdflib.NamedNode(
+const additionalStaffPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/additionalStaff'
 );
-const volunteersPredicate = new rdflib.NamedNode(
+const volunteersPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/volunteers'
 );
 
@@ -178,7 +174,7 @@ export default class CustomSubsidyFormFieldsEngagementTableEditComponent extends
 
   createEngagementTable() {
     const uuid = uuidv4();
-    this.engagementTableSubject = new rdflib.NamedNode(
+    this.engagementTableSubject = new NamedNode(
       `${engagementTableBaseUri}/${uuid}`
     );
     const triples = [
@@ -224,7 +220,7 @@ export default class CustomSubsidyFormFieldsEngagementTableEditComponent extends
     let triples = [];
 
     const uuid = uuidv4();
-    const engagementEntrySubject = new rdflib.NamedNode(
+    const engagementEntrySubject = new NamedNode(
       `${engagementEntryBaseUri}/${uuid}`
     );
 

--- a/addon/components/custom-subsidy-form-fields/engagement-table/show.js
+++ b/addon/components/custom-subsidy-form-fields/engagement-table/show.js
@@ -1,20 +1,18 @@
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { tracked } from '@glimmer/tracking';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { next } from '@ember/runloop';
+import { NamedNode } from 'rdflib';
 
 const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
-const engagementEntryPredicate = new rdflib.NamedNode(
-  `${extBaseUri}engagementEntry`
-);
-const existingStaffPredicate = new rdflib.NamedNode(
+const engagementEntryPredicate = new NamedNode(`${extBaseUri}engagementEntry`);
+const existingStaffPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/existingStaff'
 );
-const additionalStaffPredicate = new rdflib.NamedNode(
+const additionalStaffPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/additionalStaff'
 );
-const volunteersPredicate = new rdflib.NamedNode(
+const volunteersPredicate = new NamedNode(
   'http://mu.semte.ch/vocabularies/ext/volunteers'
 );
 

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/base-table.js
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/base-table.js
@@ -2,9 +2,9 @@ import { tracked } from '@glimmer/tracking';
 
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 
-export const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+export const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 export const estimatedCostTableBaseUri =
   'http://lblod.data.gift/id/subsidie/bicycle-infrastructure/table';
@@ -13,33 +13,29 @@ export const bicycleInfrastructureUri =
 export const extBaseUri = 'http://mu.semte.ch/vocabularies/ext/';
 export const subsidyRulesUri = 'http://data.lblod.info/id/subsidies/rules/';
 
-export const EstimatedCostTableType = new rdflib.NamedNode(
+export const EstimatedCostTableType = new NamedNode(
   `${bicycleInfrastructureUri}EstimatedCostTable`
 );
-export const EstimatedCostEntryType = new rdflib.NamedNode(
+export const EstimatedCostEntryType = new NamedNode(
   `${bicycleInfrastructureUri}EstimatedCostEntry`
 );
-export const estimatedCostTablePredicate = new rdflib.NamedNode(
+export const estimatedCostTablePredicate = new NamedNode(
   `${bicycleInfrastructureUri}estimatedCostTable`
 );
-export const estimatedCostEntryPredicate = new rdflib.NamedNode(
+export const estimatedCostEntryPredicate = new NamedNode(
   `${bicycleInfrastructureUri}estimatedCostEntry`
 );
 
-export const descriptionPredicate = new rdflib.NamedNode(
+export const descriptionPredicate = new NamedNode(
   `${bicycleInfrastructureUri}costEstimationType`
 );
-export const costPredicate = new rdflib.NamedNode(
-  `${bicycleInfrastructureUri}cost`
-);
-export const sharePredicate = new rdflib.NamedNode(
-  `${bicycleInfrastructureUri}share`
-);
-export const indexPredicate = new rdflib.NamedNode(`${extBaseUri}index`);
-export const validEstimatedCostTable = new rdflib.NamedNode(
+export const costPredicate = new NamedNode(`${bicycleInfrastructureUri}cost`);
+export const sharePredicate = new NamedNode(`${bicycleInfrastructureUri}share`);
+export const indexPredicate = new NamedNode(`${extBaseUri}index`);
+export const validEstimatedCostTable = new NamedNode(
   `${bicycleInfrastructureUri}validEstimatedCostTable`
 );
-export const optionsPredicate = new rdflib.NamedNode(
+export const optionsPredicate = new NamedNode(
   'http://lblod.data.gift/vocabularies/forms/options'
 );
 

--- a/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/estimated-cost-table/edit.js
@@ -1,10 +1,10 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
+import { NamedNode } from 'rdflib';
 
 import BaseTable from './base-table';
 import { EstimatedCostEntry } from './base-table';
@@ -97,7 +97,7 @@ export default class CustomSubsidyFormFieldsEstimatedCostTableEditComponent exte
 
   createEstimatedCostTable() {
     const uuid = uuidv4();
-    this.estimatedCostTableSubject = new rdflib.NamedNode(
+    this.estimatedCostTableSubject = new NamedNode(
       `${estimatedCostTableBaseUri}/${uuid}`
     );
     const triples = [
@@ -154,7 +154,7 @@ export default class CustomSubsidyFormFieldsEstimatedCostTableEditComponent exte
 
     rows.forEach((target) => {
       const uuid = uuidv4();
-      const estimatedCostEntrySubject = new rdflib.NamedNode(
+      const estimatedCostEntrySubject = new NamedNode(
         `${subsidyRulesUri}/${uuid}`
       );
 

--- a/addon/components/custom-subsidy-form-fields/objective-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/objective-table/edit.js
@@ -2,31 +2,31 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
+import { NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';
 const resourceInstanceBaseUri =
   'http://lblod.data.gift/id/subsidie/bicycle-infrastructure';
-const ObjectiveTableType = new rdflib.NamedNode(
+const ObjectiveTableType = new NamedNode(
   `${bicycleInfrastructureUri}ObjectiveTable`
 );
-const objectiveTablePredicate = new rdflib.NamedNode(
+const objectiveTablePredicate = new NamedNode(
   `${bicycleInfrastructureUri}objectiveTable`
 );
-const kilometersPredicate = new rdflib.NamedNode(
+const kilometersPredicate = new NamedNode(
   `${bicycleInfrastructureUri}kilometers`
 );
 
-const hasInvalidCellPredicate = new rdflib.NamedNode(
+const hasInvalidCellPredicate = new NamedNode(
   `${bicycleInfrastructureUri}/hasInvalidObjectiveTableEntry`
 );
-const validObjectiveTable = new rdflib.NamedNode(
+const validObjectiveTable = new NamedNode(
   `${bicycleInfrastructureUri}validObjectiveTable`
 );
 
@@ -71,7 +71,7 @@ export default class CustomSubsidyFormFieldsObjectiveTableEditComponent extends 
 
   createObjectiveTable() {
     const uuid = uuidv4();
-    this.objectiveTableSubject = new rdflib.NamedNode(
+    this.objectiveTableSubject = new NamedNode(
       `${resourceInstanceBaseUri}/${uuid}`
     );
     const triples = [

--- a/addon/components/custom-subsidy-form-fields/objective-table/table-cell.js
+++ b/addon/components/custom-subsidy-form-fields/objective-table/table-cell.js
@@ -1,41 +1,41 @@
 import Component from '@glimmer/component';
 import { schedule } from '@ember/runloop';
-import rdflib from 'browser-rdflib';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const bicycleInfrastructureUri =
   'http://lblod.data.gift/vocabularies/subsidie/bicycle-infrastructure#';
 const resourceInstanceBaseUri =
   'http://lblod.data.gift/id/subsidie/bicycle-infrastructure';
-const objectiveEntryPredicate = new rdflib.NamedNode(
+const objectiveEntryPredicate = new NamedNode(
   `${bicycleInfrastructureUri}objectiveEntry`
 );
-const ObjectiveEntryType = new rdflib.NamedNode(
+const ObjectiveEntryType = new NamedNode(
   `${bicycleInfrastructureUri}ObjectiveEntry`
 );
 
-const objectiveTablePredicate = new rdflib.NamedNode(
+const objectiveTablePredicate = new NamedNode(
   `${bicycleInfrastructureUri}objectiveTable`
 );
-const approachTypePredicate = new rdflib.NamedNode(
+const approachTypePredicate = new NamedNode(
   `${bicycleInfrastructureUri}approachType`
 );
-const directionTypePredicate = new rdflib.NamedNode(
+const directionTypePredicate = new NamedNode(
   `${bicycleInfrastructureUri}directionType`
 );
-const bikeLaneTypePredicate = new rdflib.NamedNode(
+const bikeLaneTypePredicate = new NamedNode(
   `${bicycleInfrastructureUri}bikeLaneType`
 );
-const kilometersPredicate = new rdflib.NamedNode(
+const kilometersPredicate = new NamedNode(
   `${bicycleInfrastructureUri}kilometers`
 );
 
-const hasInvalidCellPredicate = new rdflib.NamedNode(
+const hasInvalidCellPredicate = new NamedNode(
   `${bicycleInfrastructureUri}/hasInvalidObjectiveTableEntry`
 );
 
@@ -55,7 +55,7 @@ export default class CustomSubsidyFormFieldsObjectiveTableTableCellComponent ext
       null,
       this.storeOptions.sourceGraph
     );
-    return new rdflib.NamedNode(triple[0].object.value);
+    return new NamedNode(triple[0].object.value);
   }
 
   get bikeLaneType() {
@@ -160,9 +160,7 @@ export default class CustomSubsidyFormFieldsObjectiveTableTableCellComponent ext
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(
-      `${resourceInstanceBaseUri}/${uuid}`
-    );
+    const tableEntryUri = new NamedNode(`${resourceInstanceBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -276,7 +274,7 @@ export default class CustomSubsidyFormFieldsObjectiveTableTableCellComponent ext
     this.updateTripleObject(
       this.tableEntryUri,
       kilometersPredicate,
-      rdflib.literal(parsedAmount)
+      literal(parsedAmount)
     );
     return this.onUpdateCell();
   }

--- a/addon/components/custom-subsidy-form-fields/plan-living-together-table/edit.js
+++ b/addon/components/custom-subsidy-form-fields/plan-living-together-table/edit.js
@@ -4,36 +4,32 @@ import { A } from '@ember/array';
 import { action } from '@ember/object';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { scheduleOnce } from '@ember/runloop';
-import rdflib from 'browser-rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF } from '@lblod/submission-form-helpers';
+import { NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const planBaseUri =
   'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';
 const planTableBaseUri = 'http://data.lblod.info/plan-living-together-tables';
 
 const lblodSubsidieBaseUri = 'http://lblod.data.gift/vocabularies/subsidie/';
-const planTableType = new rdflib.NamedNode(
+const planTableType = new NamedNode(
   `${lblodSubsidieBaseUri}PlanLivingTogetherTable`
 );
-const planTablePredicate = new rdflib.NamedNode(
+const planTablePredicate = new NamedNode(
   `${lblodSubsidieBaseUri}planLivingTogetherTable`
 );
-const plannedRangePredicate = new rdflib.NamedNode(
-  `${planBaseUri}plannedRange`
-);
-const contributionPredicate = new rdflib.NamedNode(
-  `${planBaseUri}contribution`
-);
-const totalContributionPredicate = new rdflib.NamedNode(
+const plannedRangePredicate = new NamedNode(`${planBaseUri}plannedRange`);
+const contributionPredicate = new NamedNode(`${planBaseUri}contribution`);
+const totalContributionPredicate = new NamedNode(
   `${planBaseUri}totalContribution`
 );
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const hasInvalidRowPredicate = new NamedNode(
   `${planTableBaseUri}hasInvalidPlanLivingTogetherTableEntry`
 );
-const validPlanTable = new rdflib.NamedNode(
+const validPlanTable = new NamedNode(
   `${lblodSubsidieBaseUri}validPlanLivingTogetherTable`
 );
 
@@ -81,7 +77,7 @@ export default class CustomSubsidyFormFieldsPlanLivingTogetherTableEditComponent
 
   createPlanTable() {
     const uuid = uuidv4();
-    this.planTableSubject = new rdflib.NamedNode(`${planTableBaseUri}/${uuid}`);
+    this.planTableSubject = new NamedNode(`${planTableBaseUri}/${uuid}`);
 
     const triples = [
       {

--- a/addon/components/custom-subsidy-form-fields/plan-living-together-table/table-row.js
+++ b/addon/components/custom-subsidy-form-fields/plan-living-together-table/table-row.js
@@ -2,12 +2,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { A } from '@ember/array';
 import { action } from '@ember/object';
-import rdflib from 'browser-rdflib';
 import { scheduleOnce } from '@ember/runloop';
 import { v4 as uuidv4 } from 'uuid';
 import { RDF, XSD } from '@lblod/submission-form-helpers';
+import { literal, NamedNode, Namespace } from 'rdflib';
 
-const MU = new rdflib.Namespace('http://mu.semte.ch/vocabularies/core/');
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 const planBaseUri =
   'http://lblod.data.gift/vocabularies/subsidie/plan-samenleven/';
@@ -15,24 +15,16 @@ const planTableBaseUri = 'http://data.lblod.info/plan-living-together-tables';
 
 const tableEntryBaseUri =
   'http://data.lblod.info/id/plan-living-together-table/row-entry';
-const PlanEntryType = new rdflib.NamedNode(
-  `${planBaseUri}PlanLivingTogetherEntry`
-);
-const planEntryPredicate = new rdflib.NamedNode(
+const PlanEntryType = new NamedNode(`${planBaseUri}PlanLivingTogetherEntry`);
+const planEntryPredicate = new NamedNode(
   `${planBaseUri}planLivingTogetherEntry`
 );
-const descriptionPredicate = new rdflib.NamedNode(`${planBaseUri}description`);
-const currentRangePredicate = new rdflib.NamedNode(
-  `${planBaseUri}currentRange`
-);
-const plannedRangePredicate = new rdflib.NamedNode(
-  `${planBaseUri}plannedRange`
-);
-const contributionPredicate = new rdflib.NamedNode(
-  `${planBaseUri}contribution`
-);
-const priorityPredicate = new rdflib.NamedNode(`${planBaseUri}priority`);
-const hasInvalidRowPredicate = new rdflib.NamedNode(
+const descriptionPredicate = new NamedNode(`${planBaseUri}description`);
+const currentRangePredicate = new NamedNode(`${planBaseUri}currentRange`);
+const plannedRangePredicate = new NamedNode(`${planBaseUri}plannedRange`);
+const contributionPredicate = new NamedNode(`${planBaseUri}contribution`);
+const priorityPredicate = new NamedNode(`${planBaseUri}priority`);
+const hasInvalidRowPredicate = new NamedNode(
   `${planTableBaseUri}hasInvalidPlanLivingTogetherTableEntry`
 );
 
@@ -55,7 +47,7 @@ export default class CustomSubsidyFormFieldsPlanLivingTogetherTableTableRowCompo
   }
 
   get businessRuleUri() {
-    return new rdflib.NamedNode(this.args.businessRuleUriStr);
+    return new NamedNode(this.args.businessRuleUriStr);
   }
 
   get onUpdateRow() {
@@ -139,7 +131,7 @@ export default class CustomSubsidyFormFieldsPlanLivingTogetherTableTableRowCompo
 
   initializeDefault() {
     const uuid = uuidv4();
-    const tableEntryUri = new rdflib.NamedNode(`${tableEntryBaseUri}/${uuid}`);
+    const tableEntryUri = new NamedNode(`${tableEntryBaseUri}/${uuid}`);
 
     let triples = [
       {
@@ -338,22 +330,22 @@ export default class CustomSubsidyFormFieldsPlanLivingTogetherTableTableRowCompo
     this.updateTripleObject(
       this.tableEntryUri,
       currentRangePredicate,
-      rdflib.literal(this.currentRange, XSD('integer'))
+      literal(this.currentRange, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       plannedRangePredicate,
-      rdflib.literal(this.plannedRange, XSD('integer'))
+      literal(this.plannedRange, XSD('integer'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       contributionPredicate,
-      rdflib.literal(this.contribution, XSD('float'))
+      literal(this.contribution, XSD('float'))
     );
     this.updateTripleObject(
       this.tableEntryUri,
       priorityPredicate,
-      rdflib.literal(this.priority, XSD('integer'))
+      literal(this.priority, XSD('integer'))
     );
     this.setComponentValues(this.tableEntryUri);
 

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -8,7 +8,7 @@ import {
   SKOS,
   triplesForPath,
 } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { namedNode } from 'rdflib';
 
 export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent extends InputFieldComponent {
   id = 'multi-select-checkboxes-' + guidFor(this);
@@ -53,10 +53,10 @@ export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent e
     const { sourceGraph, metaGraph } = this.args.graphs;
     const path = this.args.field.rdflibPath;
     const options = this.args.field.options;
-    const scheme = new rdflib.namedNode(options.conceptScheme);
+    const scheme = new namedNode(options.conceptScheme);
 
     let orderBy;
-    if (options.orderBy) orderBy = new rdflib.namedNode(options.orderBy);
+    if (options.orderBy) orderBy = new namedNode(options.orderBy);
 
     this.options = store
       .match(undefined, SKOS('inScheme'), scheme, metaGraph)

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -7,8 +7,8 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
-import rdflib from 'browser-rdflib';
 import { restartableTask, timeout } from 'ember-concurrency';
+import { namedNode } from 'rdflib';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -36,7 +36,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     /**
      * NOTE: Most forms are now implemented to have a default "true" behavior

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -3,7 +3,7 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { SKOS } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { namedNode } from 'rdflib';
 
 export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends SimpleInputFieldComponent {
   inputId = 'concept-scheme-radio-buttons-' + guidFor(this);
@@ -18,7 +18,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
       .map((t) => {

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -7,7 +7,7 @@ import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { namedNode } from 'rdflib';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -31,7 +31,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new rdflib.namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     /**
      * NOTE: Most forms are now implemented to have a default "true" behavior

--- a/addon/components/rdf-input-fields/date-range.js
+++ b/addon/components/rdf-input-fields/date-range.js
@@ -7,9 +7,9 @@ import {
   BELGIAN_FORMAT_ADAPTER,
 } from '@lblod/ember-submission-form-fields/config/date-picker';
 import { SHACL } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { Namespace } from 'rdflib';
 
-const DATE_RANGE = new rdflib.Namespace(
+const DATE_RANGE = new Namespace(
   'http://data.lblod.info/form-fields/date-range/'
 );
 

--- a/addon/components/rdf-input-fields/date-time.js
+++ b/addon/components/rdf-input-fields/date-time.js
@@ -7,7 +7,7 @@ import {
   BELGIAN_FORMAT_ADAPTER,
 } from '@lblod/ember-submission-form-fields/config/date-picker';
 import { triplesForPath, XSD } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { literal } from 'rdflib';
 
 export default class RdfInputFieldsDateTimeComponent extends SimpleInputFieldComponent {
   inputId = 'date-time-' + guidFor(this);
@@ -44,9 +44,7 @@ export default class RdfInputFieldsDateTimeComponent extends SimpleInputFieldCom
       this.value.setHours(this.hour, this.minutes, null, null);
       updatedValue = this.value.toISOString();
     } */
-    const newValue = date
-      ? rdflib.literal(date.toISOString(), XSD('dateTime'))
-      : null;
+    const newValue = date ? literal(date.toISOString(), XSD('dateTime')) : null;
     super.updateValue(newValue);
     this.loadProvidedValue();
   }

--- a/addon/components/rdf-input-fields/date.js
+++ b/addon/components/rdf-input-fields/date.js
@@ -6,7 +6,7 @@ import {
   DUTCH_LOCALIZATION,
   BELGIAN_FORMAT_ADAPTER,
 } from '@lblod/ember-submission-form-fields/config/date-picker';
-import rdflib from 'browser-rdflib';
+import { literal } from 'rdflib';
 
 export default class RdfInputFieldsDateComponent extends SimpleInputFieldComponent {
   inputId = 'date-' + guidFor(this);
@@ -15,7 +15,7 @@ export default class RdfInputFieldsDateComponent extends SimpleInputFieldCompone
 
   @action
   updateValue(isoDate) {
-    const newDate = isoDate ? rdflib.literal(isoDate, XSD('date')) : null;
+    const newDate = isoDate ? literal(isoDate, XSD('date')) : null;
     super.updateValue(newDate);
   }
 }

--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -12,7 +12,7 @@ import {
   RDF,
   removeDatasetForSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode } from 'rdflib';
 
 class FileField {
   @tracked errors = [];
@@ -50,7 +50,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
       this.storeOptions.store.match(
         undefined,
         FORM('displayType'),
-        new rdflib.NamedNode('http://lblod.data.gift/display-types/remoteUrls'),
+        new NamedNode('http://lblod.data.gift/display-types/remoteUrls'),
         this.storeOptions.formGraph
       ).length > 0
     );
@@ -78,7 +78,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
   }
 
   isFileDataObject(subject) {
-    const fileDataObjectType = new rdflib.NamedNode(
+    const fileDataObjectType = new NamedNode(
       'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject'
     );
     return (
@@ -114,34 +114,31 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
   }
 
   insertFileDataObject(fileUri) {
-    const fileDataObjectType = new rdflib.NamedNode(
+    const fileDataObjectType = new NamedNode(
       'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject'
     );
     const typeT = {
-      subject: new rdflib.NamedNode(fileUri),
+      subject: new NamedNode(fileUri),
       predicate: RDF('type'),
       object: fileDataObjectType,
       graph: this.storeOptions.sourceGraph,
     };
     this.storeOptions.store.addAll([typeT]);
-    addSimpleFormValue(new rdflib.NamedNode(fileUri), this.storeOptions);
+    addSimpleFormValue(new NamedNode(fileUri), this.storeOptions);
   }
 
   removeFileDataObject(fileUri) {
-    const fileDataObjectType = new rdflib.NamedNode(
+    const fileDataObjectType = new NamedNode(
       'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject'
     );
     const typeT = {
-      subject: new rdflib.NamedNode(fileUri),
+      subject: new NamedNode(fileUri),
       predicate: RDF('type'),
       object: fileDataObjectType,
       graph: this.storeOptions.sourceGraph,
     };
     this.storeOptions.store.removeStatements([typeT]);
-    removeDatasetForSimpleFormValue(
-      new rdflib.NamedNode(fileUri),
-      this.storeOptions
-    );
+    removeDatasetForSimpleFormValue(new NamedNode(fileUri), this.storeOptions);
   }
 
   @action

--- a/addon/components/rdf-input-fields/input-field.js
+++ b/addon/components/rdf-input-fields/input-field.js
@@ -8,7 +8,7 @@ import {
   validationResultsForField,
   validationTypesForField,
 } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode } from 'rdflib';
 
 const MAX_LENGTH_URI = 'http://lblod.data.gift/vocabularies/forms/MaxLength';
 /**
@@ -67,7 +67,7 @@ export default class InputFieldComponent extends Component {
       store.any(
         constraint,
         RDF('type'),
-        new rdflib.NamedNode(MAX_LENGTH_URI),
+        new NamedNode(MAX_LENGTH_URI),
         formGraph
       )
     );

--- a/addon/components/rdf-input-fields/numerical-input.js
+++ b/addon/components/rdf-input-fields/numerical-input.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { XSD } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { literal } from 'rdflib';
 
 export default class RdfInputFieldsNumericalInputComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
@@ -10,7 +10,7 @@ export default class RdfInputFieldsNumericalInputComponent extends SimpleInputFi
   @action
   updateValue(e) {
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
-    const number = rdflib.literal(Number(this.value), this.datatype);
+    const number = literal(Number(this.value), this.datatype);
     super.updateValue(number);
   }
 

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -8,17 +8,17 @@ import {
   addSimpleFormValue,
   removeSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
 import { RDF, NIE } from '@lblod/submission-form-helpers';
+import { namedNode, NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { guidFor } from '@ember/object/internals';
 
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
-const REQUEST_HEADER = new rdflib.namedNode(
+const REQUEST_HEADER = new namedNode(
   'http://data.lblod.info/request-headers/29b14d06-e584-45d6-828a-ce1f0c018a8e'
 );
 
-const RPIO_HTTP = new rdflib.Namespace(
+const RPIO_HTTP = new Namespace(
   'http://redpencil.data.gift/vocabularies/http/'
 );
 
@@ -89,7 +89,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
   }
 
   isRemoteDataObject(subject) {
-    const remoteDataObjectType = new rdflib.NamedNode(
+    const remoteDataObjectType = new NamedNode(
       'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'
     );
     return (
@@ -139,7 +139,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     if (remoteObjecTs.length) {
       this.storeOptions.store.removeStatements(remoteObjecTs);
     }
-    removeSimpleFormValue(new rdflib.NamedNode(uri), this.storeOptions); // remove hasPart
+    removeSimpleFormValue(new NamedNode(uri), this.storeOptions); // remove hasPart
   }
 
   insertRemoteDataObject({ uri, address }) {
@@ -147,7 +147,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
       {
         subject: uri,
         predicate: RDF('type'),
-        object: new rdflib.NamedNode(
+        object: new NamedNode(
           'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'
         ),
         graph: this.storeOptions.sourceGraph,
@@ -174,7 +174,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
   addUrlField() {
     this.remoteUrls.pushObject(
       new RemoteUrl({
-        uri: new rdflib.namedNode(REMOTE_URI_TEMPLATE + `${uuidv4()}`),
+        uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuidv4()}`),
         address: '',
         errors: [],
       })

--- a/addon/components/rdf-input-fields/remote-urls/show.js
+++ b/addon/components/rdf-input-fields/remote-urls/show.js
@@ -6,7 +6,7 @@ import { guidFor } from '@ember/object/internals';
 import { A } from '@ember/array';
 
 import { RDF } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode } from 'rdflib';
 
 export default class FormInputFieldsRemoteUrlsShowComponent extends InputFieldComponent {
   inputId = 'remote-urls-' + guidFor(this);
@@ -37,7 +37,7 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends InputFieldCo
   }
 
   isRemoteDataObject(subject) {
-    const remoteDataObjectType = new rdflib.NamedNode(
+    const remoteDataObjectType = new NamedNode(
       'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'
     );
     return (

--- a/addon/components/rdf-input-fields/simple-value-input-field.js
+++ b/addon/components/rdf-input-fields/simple-value-input-field.js
@@ -3,7 +3,7 @@ import InputFieldComponent from './input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { updateSimpleFormValue } from '@lblod/submission-form-helpers';
 import { next } from '@ember/runloop';
-import rdflib from 'browser-rdflib';
+import { isLiteral, Literal } from 'rdflib';
 
 export default class SimpleValueInputFieldComponent extends InputFieldComponent {
   @tracked value = null;
@@ -16,7 +16,7 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
 
   loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);
-    const literals = matches.values.filter((value) => rdflib.isLiteral(value));
+    const literals = matches.values.filter((value) => isLiteral(value));
 
     if (literals.length) {
       let literal;
@@ -41,14 +41,14 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
         }
       }
 
-      if(literal) {
+      if (literal) {
         this.nodeValue = literal;
         this.value = literal.value;
       }
     }
 
     if (!this.nodeValue && this.args.field.language) {
-      this.nodeValue = new rdflib.Literal('', this.args.field.language);
+      this.nodeValue = new Literal('', this.args.field.language);
     }
 
     if (this.defaultValue && this.value == null) {
@@ -62,7 +62,7 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
   updateValue(value) {
     let literalOrValue;
 
-    if (value && rdflib.isLiteral(value)) {
+    if (value && isLiteral(value)) {
       literalOrValue = value;
     } else {
       literalOrValue = this.nodeValue?.copy();

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.js
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.js
@@ -4,18 +4,18 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { RDF, triplesForPath } from '@lblod/submission-form-helpers';
-import rdflib from 'browser-rdflib';
+import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 
 const uriTemplate = 'http://data.lblod.info/tax-rates';
 const lblodBesluit = `http://lblod.data.gift/vocabularies/besluit`;
 
-const TaxRateType = new rdflib.NamedNode(`${lblodBesluit}/TaxRate`);
-const hasAdditionalTaxRate = new rdflib.NamedNode(
+const TaxRateType = new NamedNode(`${lblodBesluit}/TaxRate`);
+const hasAdditionalTaxRate = new NamedNode(
   `${lblodBesluit}/hasAdditionalTaxRate`
 );
-const schemaPrice = new rdflib.NamedNode(`http://schema.org/price`);
-const taxRate = new rdflib.NamedNode(`${lblodBesluit}/taxRate`);
+const schemaPrice = new NamedNode(`http://schema.org/price`);
+const taxRate = new NamedNode(`${lblodBesluit}/taxRate`);
 
 class TaxEntry {
   @tracked oldValue;
@@ -136,7 +136,7 @@ export default class RdfInputFieldsVlabelOpcentiemComponent extends InputFieldCo
   }
 
   createTaxRate() {
-    this.taxRateSubject = new rdflib.NamedNode(`${uriTemplate}/${uuidv4()}`);
+    this.taxRateSubject = new NamedNode(`${uriTemplate}/${uuidv4()}`);
     const triples = [
       {
         subject: this.taxRateSubject,

--- a/package.json
+++ b/package.json
@@ -29,9 +29,8 @@
   "dependencies": {
     "@embroider/macros": "^1.6.0",
     "@embroider/util": "^1.6.0",
-    "@lblod/submission-form-helpers": "^1.4.1",
+    "@lblod/submission-form-helpers": "^2.0.1",
     "broccoli-funnel": "^3.0.8",
-    "browser-rdflib": "^1.1.0",
     "clipboardy": "^2.3.0",
     "ember-auto-import": "^2.2.4",
     "ember-cli-babel": "^7.26.11",
@@ -41,7 +40,8 @@
     "ember-named-blocks-polyfill": "^0.2.5",
     "ember-test-selectors": "^5.0.0 || ^6.0.0",
     "ember-truth-helpers": "^3.0.0",
-    "forking-store": "^1.0.0",
+    "forking-store": "^2.0.0",
+    "rdflib": "^2.2.19",
     "uuid": "^7.0.3"
   },
   "peerDependencies": {

--- a/tests/dummy/app/components/test-form.js
+++ b/tests/dummy/app/components/test-form.js
@@ -1,14 +1,14 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import rdflib from 'browser-rdflib';
+import { NamedNode } from 'rdflib';
 
 const FORM_GRAPHS = {
-  formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
-  metaGraph: new rdflib.NamedNode('http://data.lblod.info/metagraph'),
-  sourceGraph: new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`),
+  formGraph: new NamedNode('http://data.lblod.info/form'),
+  metaGraph: new NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new NamedNode(`http://data.lblod.info/sourcegraph`),
 };
 
-const SOURCE_NODE = new rdflib.NamedNode(
+const SOURCE_NODE = new NamedNode(
   'http://ember-submission-form-fields/source-node'
 );
 

--- a/tests/dummy/app/routes/form.js
+++ b/tests/dummy/app/routes/form.js
@@ -1,17 +1,17 @@
 import Route from '@ember/routing/route';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import rdflib from 'browser-rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 
 const FORM_GRAPHS = {
-  formGraph: new rdflib.NamedNode('http://data.lblod.info/form'),
-  metaGraph: new rdflib.NamedNode('http://data.lblod.info/metagraph'),
-  sourceGraph: new rdflib.NamedNode(`http://data.lblod.info/sourcegraph`),
+  formGraph: new NamedNode('http://data.lblod.info/form'),
+  metaGraph: new NamedNode('http://data.lblod.info/metagraph'),
+  sourceGraph: new NamedNode(`http://data.lblod.info/sourcegraph`),
 };
 
-const SOURCE_NODE = new rdflib.NamedNode(`http://data.lblod.info/sourceNode`);
+const SOURCE_NODE = new NamedNode(`http://data.lblod.info/sourceNode`);
 
-const FORM = new rdflib.Namespace('http://lblod.data.gift/vocabularies/forms/');
-const RDF = new rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
+const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
+const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 
 const FORM_TITLES = {
   'basic-fields': 'Basic form fields',


### PR DESCRIPTION
rdflib v2 is browser compatible so we no longer need the browser-rdflib package (which is based on rdflib v1).