### PR TITLE
Remove `@renderInPlace` from the ConceptSchemeSelector component

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.hbs
@@ -7,7 +7,6 @@
 </AuLabel>
 <div class={{if this.hasErrors "ember-power-select--error"}}>
   <PowerSelect
-    @renderInPlace={{true}}
     @triggerId={{this.inputId}}
     @searchField="label"
     @searchEnabled={{this.searchEnabled}}


### PR DESCRIPTION
`ConceptSchemeSelector` is the only component that uses the `@renderInPlace` argument, which makes the component behave differently from the other select fields. This difference in behavior is problematic for the automated testing setup. Removing the argument makes the behavior consistent with the other select components.

`@renderInPlace` should only be needed if the wormhole based rendering causes problems, which can happen if the select is used in things like modals.