### PR TITLE
Remove ember-test-selectors

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,13 +7,6 @@ module.exports = function (defaults) {
     // Add options here
   };
 
-  if (process.env.EMBER_TEST_SELECTORS_STRIP == 'false') {
-    customBuildConfig['ember-test-selectors'] = { strip: false };
-  } else if (process.env.EMBER_TEST_SELECTORS_STRIP == 'true') {
-    customBuildConfig['ember-test-selectors'] = { strip: true };
-  }
-  //if EMBER_TEST_SELECTORS_STRIP left unspecificied, we fall back to default behavoir
-
   let app = new EmberAddon(defaults, customBuildConfig);
 
   /*

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-concurrency": "^2.0.0",
     "ember-math-helpers": "^2.18.1",
-    "ember-test-selectors": "^5.0.0 || ^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "forking-store": "^2.0.0",
     "rdflib": "^2.2.19",


### PR DESCRIPTION
It's better that the app decides if the test selector attributes need to be removed.