### PR TITLE
Fallback to an empty string if a literal value is null or undefined

### DIFF
--- a/addon/components/rdf-input-fields/simple-value-input-field.js
+++ b/addon/components/rdf-input-fields/simple-value-input-field.js
@@ -67,7 +67,7 @@ export default class SimpleValueInputFieldComponent extends InputFieldComponent 
     } else {
       literalOrValue = this.nodeValue?.copy();
       if (literalOrValue) {
-        literalOrValue.value = value;
+        literalOrValue.value = value || '';
       } else {
         literalOrValue = value;
       }


### PR DESCRIPTION
Rdflib literals can only have string or number values and will throw an error if `null` is passed.