### PR TITLE
Make the PropertyGroup title level and skin configurable

### DIFF
--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -1,13 +1,15 @@
 {{#if this.children}}
   <div ...attributes>
-    {{#if @group.name}}
+    {{#if this.showTitleBlock}}
       <div class="au-u-margin-bottom-small">
-        <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
-          {{@group.name}}
-        </AuHeading>
+        {{#if @group.name}}
+          <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
+            {{@group.name}}
+          </AuHeading>
+        {{/if}}
         {{#if @group.help}}
           {{! template-lint-disable no-triple-curlies}}
-          <p class="au-u-light au-u-margin-top-xsmall">{{{@group.help}}}</p>
+          <p class="au-u-light">{{{@group.help}}}</p>
         {{/if}}
         {{#each this.errors as |error|}}
           <AuAlert class="au-u-margin-bottom-small au-u-margin-top-small"

--- a/addon/components/property-group.js
+++ b/addon/components/property-group.js
@@ -31,7 +31,7 @@ export default class SubmissionFormPropertyGroupComponent extends Component {
   }
 
   get level() {
-    return this.args.level || 1;
+    return this.args.group.options.level || this.args.level || 1;
   }
 
   get titleLevel() {
@@ -39,11 +39,15 @@ export default class SubmissionFormPropertyGroupComponent extends Component {
   }
 
   get titleSkin() {
-    return `${this.level + 1}`;
+    return this.args.group.options.skin || `${this.level + 1}`;
   }
 
   get nextLevel() {
     return this.level + 1;
+  }
+
+  get showTitleBlock() {
+    return Boolean(this.args.group.name) || Boolean(this.args.group.help);
   }
 
   get errors() {

--- a/addon/models/property-group.js
+++ b/addon/models/property-group.js
@@ -1,5 +1,4 @@
 import { tracked } from '@glimmer/tracking';
-
 import { FORM, SHACL } from '@lblod/submission-form-helpers';
 
 export const PROPERTY_GROUP_DISPLAY_TYPE =
@@ -25,6 +24,7 @@ export default class PropertyGroupModel {
       formGraph
     );
     this.rdflibHelp = store.any(uri, FORM('help'), undefined, formGraph);
+    this.rdflibOptions = store.any(uri, FORM('options'), undefined, formGraph);
   }
 
   @tracked
@@ -56,6 +56,18 @@ export default class PropertyGroupModel {
 
   get sortedFields() {
     return this.fields.sort((a, b) => a.order > b.order);
+  }
+
+  get options() {
+    let options;
+
+    try {
+      options = JSON.parse(this.rdflibOptions?.value);
+    } catch {
+      options = {};
+    }
+
+    return options;
   }
 
   get displayType() {


### PR DESCRIPTION
This allows us to override the default level 1 / skin 2 combo. Overriding the level also affects the levels of nested PropertyGroups, so simply setting this on the root PropertyGroup should work. The "skin" can also be adjusted in case a different visual style is needed for the design.

`skin` and `level` support the same values as the [AuHeading component](https://appuniversum.github.io/ember-appuniversum/?path=/story/components-content-auheading--component).

Allowing to change the level means we can fit in a form on a page which already has h* elements, and still output a valid header hierarchy.