### PR TITLE
Fix a bug in the listing creation code

### DIFF
--- a/addon/components/listing.js
+++ b/addon/components/listing.js
@@ -184,11 +184,11 @@ export default class ListingComponent extends Component {
     //TODO: probably this type of boilerplate should be residing elsewhere
     const allSourceNodes = [];
     const { sourceNode, pathElement } = this.sourceForHasManyConnection();
-    if (pathElement.inversPath) {
+    if (pathElement.inversePath) {
       for (const targetNode of nodes) {
         allSourceNodes.push({
           subject: targetNode,
-          predicate: pathElement.inversPath,
+          predicate: pathElement.inversePath,
           object: sourceNode,
           graph: this.graphs.sourceGraph,
         });


### PR DESCRIPTION
The creation of new entries based on an inverse path was throwing errors due to a typo.