### PR TITLE
Added requiredlabel for remote-urls

### DIFF
--- a/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
+++ b/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
@@ -9,5 +9,5 @@
   @show={{@show}}
   {{! TODO: The requiredLabel argument is the only reason why this custom component is needed.
     Should we make the form config more flexible so extra data can be passed? }}
-  @requiredLabel="Voorkeur"
+  @requiredLabel={{this.requiredLabel}}
 />

--- a/addon/components/rdf-input-fields/remote-urls/edit.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/edit.hbs
@@ -1,7 +1,7 @@
 <AuLabel
   @error={{this.hasErrors}}
   @required={{this.isRequired}}
-  @requiredLabel={{@requiredLabel}}
+  @requiredLabel={{this.requiredLabel}}
   for={{this.inputFor}}
 >
   {{@field.label}}

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -50,6 +50,10 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     return this.inputId;
   }
 
+  get requiredLabel(){
+    return this.args.field.options.requiredLabel || "Voorkeur";
+  }
+
   @tracked remoteUrls = A();
 
   observerLabel = `remote-urls-${guidFor(this)}`; // Could have used uuidv4, but more consistent accross components

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -252,15 +252,37 @@ fieldGroups:main form:hasField fields:797b6eb4-537b-4f6a-88c3-8c5421c589ab .
 ##########################################################
 fields:3fb43220-0cf2-441e-9d7c-c2e10b67c537 a form:Field ;
     mu:uuid "3fb43220-0cf2-441e-9d7c-c2e10b67c537";
-    sh:name "Url selector" ;
+    sh:name "Url selector DEFAULT REQUIREDLABEL" ;
     sh:order 310 ;
     sh:path ext:756ca950-f35b-46c5-ab3d-fd99886e91f7 ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path ext:756ca950-f35b-46c5-ab3d-fd99886e91f7 ] ;
     form:options """{}""" ;
     form:displayType displayTypes:remoteUrls ;
 
     sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
 
 fieldGroups:main form:hasField fields:3fb43220-0cf2-441e-9d7c-c2e10b67c537 .
+
+fields:3fb43220-0cf2-441e-9d7c-c2e10b67c538 a form:Field ;
+    mu:uuid "3fb43220-0cf2-441e-9d7c-c2e10b67c538";
+    sh:name "Url selector CUSTOM REQUIREDLABEL" ;
+    sh:order 311 ;
+    sh:path ext:756ca950-f35b-46c5-ab3d-fd99886e91f8 ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path ext:756ca950-f35b-46c5-ab3d-fd99886e91f8 ] ;
+    form:options """{ "requiredLabel": "Custom"}""" ;
+    form:displayType displayTypes:remoteUrls ;
+
+    sh:group fields:8e24d707-0e29-45b5-9bbf-a39e4fdb2c11 .
+
+fieldGroups:main form:hasField fields:3fb43220-0cf2-441e-9d7c-c2e10b67c538 .
 
 ##########################################################
 # Files


### PR DESCRIPTION
Added some code to differentiate the requiredLabel of remote-urls.
Currently, the requiredLabel is always "Voorkeur", but in some cases, it should be "Verplicht", for example when only URLs are requested (not files). Code added some code to edit.js of both remote-urls and default value is "Voorkeur" so old fields are not affected. 

`files.hbs` uses the following:  `@requiredLabel={{if this.containsRemoteUrls "Enkel indien geen links"}}` 
But I don't think this fits the other way around.