### PR TITLE
Add a "table-mode" to the listing component

### DIFF
--- a/addon/components/listing.hbs
+++ b/addon/components/listing.hbs
@@ -7,7 +7,7 @@
   @level={{@level}}
   @removeEntry={{this.removeEntry}}
   @canAdd={{this.canAdd}}
-  @canRemove={{@listing.canRemove}}
+  @canRemove={{this.canRemove}}
   @createEntry={{this.createEntry}}
   @listing={{@listing}}
   @sourceNode={{@sourceNode}}

--- a/addon/components/listing.hbs
+++ b/addon/components/listing.hbs
@@ -1,32 +1,14 @@
-<div class="au-o-grid">
-  <div class="au-o-grid__item au-u-4-5">
-    {{#each this.subForms as |subForm index|}}
-      <SubForm
-        @subForm={{subForm}}
-        @formStore={{@formStore}}
-        @graphs={{@graphs}}
-        @sourceNode={{subForm.sourceNode}}
-        @forceShowErrors={{@forceShowErrors}}
-        @cacheConditionals={{@cacheConditionals}}
-        @last={{eq index (sub this.subForms.length 1)}}
-        @show={{@show}}
-        @level={{@level}}
-        @onRemoveEntry={{this.removeEntry}}
-        @canRemove={{@listing.canRemove}}
-      />
-    {{/each}}
-  </div>
-  {{#if this.canAdd}}
-    <div class="au-o-grid__item au-u-1-5">
-      <AuButton
-        @icon="plus"
-        @iconAlignment="left"
-        class="au-u-margin-bottom-tiny"
-        @disabled={{this.creationFormData}}
-        {{on "click" this.createEntry}}
-      >
-        {{@listing.addLabel}}
-      </AuButton>
-    </div>
-  {{/if}}
-</div>
+<this.ListingDisplayMode
+  @subForms={{this.subForms}}
+  @formStore={{@formStore}}
+  @graphs={{@graphs}}
+  @forceShowErrors={{@forceShowErrors}}
+  @show={{@show}}
+  @level={{@level}}
+  @removeEntry={{this.removeEntry}}
+  @canAdd={{this.canAdd}}
+  @canRemove={{@listing.canRemove}}
+  @createEntry={{this.createEntry}}
+  @listing={{@listing}}
+  @sourceNode={{@sourceNode}}
+/>

--- a/addon/components/listing.js
+++ b/addon/components/listing.js
@@ -46,6 +46,10 @@ export default class ListingComponent extends Component {
     }
   }
 
+  get canRemove() {
+    return this.listing.canRemove && !this.args.show;
+  }
+
   get ListingDisplayMode() {
     return this.listing.isTable ? ListingTable : ListingList;
   }

--- a/addon/components/listing.js
+++ b/addon/components/listing.js
@@ -9,6 +9,8 @@ import {
 } from '@lblod/submission-form-helpers';
 import { getSubFormsForNode } from '../utils/model-factory';
 import { next } from '@ember/runloop';
+import ListingList from '@lblod/ember-submission-form-fields/components/listing/list';
+import ListingTable from '@lblod/ember-submission-form-fields/components/listing/table';
 
 export default class ListingComponent extends Component {
   @tracked subForms = A();
@@ -42,6 +44,10 @@ export default class ListingComponent extends Component {
     } else {
       return false;
     }
+  }
+
+  get ListingDisplayMode() {
+    return this.listing.isTable ? ListingTable : ListingList;
   }
 
   constructor() {

--- a/addon/components/listing/list.hbs
+++ b/addon/components/listing/list.hbs
@@ -12,7 +12,7 @@
         @show={{@show}}
         @level={{@level}}
         @onRemoveEntry={{@removeEntry}}
-        @canRemove={{@listing.canRemove}}
+        @canRemove={{@canRemove}}
       />
     {{/each}}
   </div>

--- a/addon/components/listing/list.hbs
+++ b/addon/components/listing/list.hbs
@@ -1,0 +1,32 @@
+<div class="au-o-grid">
+  <div class="au-o-grid__item au-u-4-5">
+    {{#each @subForms as |subForm index|}}
+      <SubForm
+        @subForm={{subForm}}
+        @formStore={{@formStore}}
+        @graphs={{@graphs}}
+        @sourceNode={{subForm.sourceNode}}
+        @forceShowErrors={{@forceShowErrors}}
+        @cacheConditionals={{@cacheConditionals}}
+        @last={{eq index (sub @subForms.length 1)}}
+        @show={{@show}}
+        @level={{@level}}
+        @onRemoveEntry={{@removeEntry}}
+        @canRemove={{@listing.canRemove}}
+      />
+    {{/each}}
+  </div>
+  {{#if @canAdd}}
+    <div class="au-o-grid__item au-u-1-5">
+      <AuButton
+        @icon="plus"
+        @iconAlignment="left"
+        class="au-u-margin-bottom-tiny"
+        @disabled={{@creationFormData}}
+        {{on "click" @createEntry}}
+      >
+        {{@listing.addLabel}}
+      </AuButton>
+    </div>
+  {{/if}}
+</div>

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -39,7 +39,7 @@
           @forceShowErrors={{@forceShowErrors}}
           @show={{@show}}
           @onRemoveEntry={{@removeEntry}}
-          @canRemove={{@listing.canRemove}}
+          @canRemove={{@canRemove}}
           @removeLabel={{@listing.removeLabel}}
         />
       {{else}}

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -1,0 +1,65 @@
+<div ...attributes>
+  <AuTable class="listing-table">
+    {{! TODO: Named blocks can't be rendered conditionally yet, so we would have to duplicate the component and all the other blocks as a workaround.
+        Since the title is only a "nice to have" we'll disable it for now until a better solution is found.
+    }}
+    {{!--
+    <:title>
+      {{this.title}}
+    </:title>
+    --}}
+    <:header>
+      {{#each this.tableHeaders as |column|}}
+        <th>
+          {{column.label}}
+
+          {{#if column.help}}
+            <AuHelpText
+              @skin="secondary"
+              @size="small"
+              class="au-u-margin-top-none au-u-regular"
+            >
+              {{column.help}}
+            </AuHelpText>
+          {{/if}}
+        </th>
+      {{/each}}
+
+      {{#if @canRemove}}
+        <th>{{! delete }}</th>
+      {{/if}}
+    </:header>
+    <:body>
+      {{#each @subForms as |subForm|}}
+        <this.ListingTableRow
+          @subForm={{subForm}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{subForm.sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @show={{@show}}
+          @onRemoveEntry={{@removeEntry}}
+          @canRemove={{@listing.canRemove}}
+          @removeLabel={{@listing.removeLabel}}
+        />
+      {{else}}
+        <tr>
+          <td colspan="100%">{{@listing.noDataMessage}}</td>
+        </tr>
+      {{/each}}
+    </:body>
+  </AuTable>
+
+  {{#if @canAdd}}
+    <AuButton
+      @icon="plus"
+      @iconAlignment="left"
+      @skin="secondary"
+      @width="block"
+      class="au-u-margin-top-small"
+      {{on "click" @createEntry}}
+    >
+      {{@listing.addLabel}}
+    </AuButton>
+  {{/if}}
+</div>

--- a/addon/components/listing/table.js
+++ b/addon/components/listing/table.js
@@ -1,0 +1,65 @@
+import Component from '@glimmer/component';
+import { SHACL, FORM, fieldsForForm } from '@lblod/submission-form-helpers';
+import ListingTableRow from './table/row';
+import Field from '@lblod/ember-submission-form-fields/models/field';
+
+export default class ListingTableComponent extends Component {
+  ListingTableRow = ListingTableRow;
+
+  constructor() {
+    super(...arguments);
+
+    let store = this.args.formStore;
+    let graphs = this.args.graphs;
+    let listingTableNode = this.args.listing.uri;
+
+    const tableSubForm = store.any(
+      listingTableNode,
+      FORM('each'),
+      undefined,
+      graphs.formGraph
+    );
+
+    this.title = this.getTableTitle(tableSubForm);
+
+    let fields = fieldsForForm(tableSubForm, {
+      store,
+      formGraph: graphs.formGraph,
+      sourceGraph: graphs.sourceGraph,
+      metaGraph: graphs.metaGraph,
+      sourceNode: listingTableNode,
+    });
+    this.tableHeaders = this.getTableHeaders(fields);
+  }
+
+  getTableTitle(tableForm) {
+    let formTitleTriple = this.args.formStore.any(
+      tableForm,
+      SHACL('name', undefined, this.args.graphs.formGraph)
+    );
+
+    return formTitleTriple?.value;
+  }
+
+  getTableHeaders(tableFields) {
+    return tableFields
+      .map((fieldUri) => {
+        return new Field(fieldUri, {
+          store: this.args.formStore,
+          formGraph: this.args.graphs.formGraph,
+        });
+      })
+      .map((field) => {
+        return {
+          label: field.label,
+          help: field.help,
+          order: field.order,
+        };
+      })
+      .sort(sortByOrder);
+  }
+}
+
+function sortByOrder(fieldA, fieldB) {
+  return fieldA.order - fieldB.order;
+}

--- a/addon/components/listing/table/row.hbs
+++ b/addon/components/listing/table/row.hbs
@@ -1,0 +1,32 @@
+<tr ...attributes>
+  {{#each this.fields as |field|}}
+    {{#let
+      (component-for-display-type field.displayType show=@show)
+      as |FormField|
+    }}
+      <td>
+        <FormField
+          @field={{field}}
+          @form={{@form}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{@sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @show={{@show}}
+          @inTable={{true}}
+        />
+      </td>
+    {{/let}}
+  {{/each}}
+  {{#if @canRemove}}
+    <td>
+      <AuButton
+        @skin="naked"
+        @alert={{true}}
+        @icon="bin"
+        {{on "click" (fn @onRemoveEntry @sourceNode)}}
+      >{{@removeLabel}}</AuButton>
+    </td>
+  {{/if}}
+</tr>

--- a/addon/components/listing/table/row.js
+++ b/addon/components/listing/table/row.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+import {
+  getChildrenForPropertyGroup,
+  getTopLevelPropertyGroups,
+} from '@lblod/ember-submission-form-fields/utils/model-factory';
+
+export default class ListingTableRow extends Component {
+  constructor() {
+    super(...arguments);
+
+    let { formStore: store, graphs, sourceNode: node } = this.args;
+
+    // We assume there will only ever be a single property group for the ListingTable
+    let propertyGroups = getTopLevelPropertyGroups({
+      store,
+      graphs,
+      form: this.args.subForm.uri,
+    });
+
+    this.fields = getChildrenForPropertyGroup(propertyGroups[0], {
+      form: this.args.subForm.uri,
+      store,
+      graphs,
+      node,
+    });
+  }
+}

--- a/addon/components/rdf-input-fields/concept-scheme-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.hbs
@@ -1,10 +1,12 @@
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{this.isRequired}}
-  for={{this.inputId}}
->
-  {{@field.label}}
-</AuLabel>
+{{#unless @inTable}}
+  <AuLabel
+    @error={{this.hasErrors}}
+    @required={{this.isRequired}}
+    for={{this.inputId}}
+  >
+    {{@field.label}}
+  </AuLabel>
+{{/unless}}
 <div class={{if this.hasErrors "ember-power-select--error"}}>
   <PowerSelect
     @triggerId={{this.inputId}}

--- a/addon/components/rdf-input-fields/input.hbs
+++ b/addon/components/rdf-input-fields/input.hbs
@@ -1,3 +1,4 @@
+{{#unless @inTable}}
 <AuLabel
   @error={{this.hasErrors}}
   @required={{this.isRequired}}
@@ -11,6 +12,7 @@
     </AuPill>
   {{/if}}
 </AuLabel>
+{{/unless}}
 
 <AuInput
   @error={{this.hasErrors}}

--- a/addon/components/rdf-input-fields/numerical-input.hbs
+++ b/addon/components/rdf-input-fields/numerical-input.hbs
@@ -1,10 +1,12 @@
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{this.isRequired}}
-  for={{this.inputId}}
->
-  {{@field.label}}
-</AuLabel>
+{{#unless @inTable}}
+  <AuLabel
+    @error={{this.hasErrors}}
+    @required={{this.isRequired}}
+    for={{this.inputId}}
+  >
+    {{@field.label}}
+  </AuLabel>
+{{/unless}}
 <AuInput
   @error={{this.hasErrors}}
   @value={{this.value}}

--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -23,7 +23,7 @@
     {{/each}}
   </div>
 
-  {{#if this.canRemove}}
+  {{#if @canRemove}}
     <div class="au-o-grid__item au-u-1-5">
       <AuButton
         @skin="link"

--- a/addon/components/sub-form.js
+++ b/addon/components/sub-form.js
@@ -12,11 +12,4 @@ export default class SubFormComponent extends Component {
       form: this.args.subForm.uri,
     });
   }
-  get canRemove() {
-    if (this.args.show) {
-      return false;
-    } else {
-      return this.args.canRemove;
-    }
-  }
 }

--- a/addon/models/listing.js
+++ b/addon/models/listing.js
@@ -1,5 +1,5 @@
 import { tracked } from '@glimmer/tracking';
-import { SHACL, FORM } from '@lblod/submission-form-helpers';
+import { SHACL, FORM, RDF } from '@lblod/submission-form-helpers';
 
 export const LISTING_TYPE = 'http://lblod.data.gift/vocabularies/forms/Listing';
 
@@ -35,6 +35,17 @@ export default class ListingModel {
       undefined,
       formGraph
     );
+
+    this.removeLabel =
+      store.any(uri, FORM('removeLabel'), undefined, formGraph)?.value ||
+      'Remove item';
+
+    this.noDataMessage =
+      store.any(uri, FORM('noDataMessage'), undefined, formGraph)?.value ||
+      'No items';
+
+    this.isTable =
+      store.match(uri, RDF('type'), FORM('ListingTable'), formGraph).length > 0;
   }
 
   @tracked

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -47,3 +47,8 @@
 .data-table.data-table--zebra tbody tr:nth-child(odd) {
   background-color: #f3f5f6;
 }
+
+/* By default the content of cells is aligned to the baseline which looks strange for most form fields */
+.listing-table td {
+  vertical-align: top;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -51,6 +51,12 @@
                   Language string support
                 </AuNavigationLink>
               </li>
+
+              <li class="au-c-list-navigation__item">
+                <AuNavigationLink @route="form" @model="tables">
+                  Tables
+                </AuNavigationLink>
+              </li>
             </ul>
           </nav>
         </div>

--- a/tests/dummy/app/templates/form.hbs
+++ b/tests/dummy/app/templates/form.hbs
@@ -5,6 +5,9 @@
   @formStore={{@model.formStore}}
   @forceShowErrors={{this.forceShowErrors}}
 />
+
+<AuHr />
+
 <AuButton
   {{on "click" this.validate}}>
   validate

--- a/tests/dummy/public/test-forms/tables/data.ttl
+++ b/tests/dummy/public/test-forms/tables/data.ttl
@@ -1,0 +1,15 @@
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+<http://ember-submission-form-fields/source-node> a ext:form;
+  ext:administrativeUnit <http://administrative-unit/1>;
+  ext:administrativeUnit <http://administrative-unit/2>.
+
+<http://administrative-unit/1> a ext:AdministrativeUnit;
+  ext:name <http://example.concept/concepts/brugge>;
+  ext:typeOfInvolvement <http://example.concept/concepts/mede-financierend>;
+  ext:involvementPercentage 2.
+
+<http://administrative-unit/2> a ext:AdministrativeUnit;
+  ext:name <http://example.concept/concepts/antwerpen>;
+  ext:typeOfInvolvement <http://example.concept/concepts/toezichthoudend>;
+  ext:involvementPercentage 0.

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -60,6 +60,11 @@ ext:administrativeUnitNameF a form:Field ;
     sh:path ext:name ;
     form:options """{"conceptScheme":"http://example.concept/concept-schemes/administrative-units","searchEnabled":false}""" ;
     form:displayType displayTypes:conceptSchemeSelector ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path ext:name] ;
     sh:group ext:mainPg .
 
 ##########################################################
@@ -71,6 +76,11 @@ ext:administrativeUnitTypeOfInvolvementF a form:Field ;
     sh:path ext:typeOfInvolvement ;
     form:options """{"conceptScheme":"http://example.concept/concept-schemes/type-of-involvement","searchEnabled":false}""" ;
     form:displayType displayTypes:conceptSchemeSelector ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht."@nl;
+        sh:path ext:typeOfInvolvement] ;
     sh:group ext:mainPg .
 
 ##########################################################
@@ -83,6 +93,11 @@ ext:administrativeUnitInvolvementPercentageF a form:Field ;
     sh:path ext:involvementPercentage;
     form:options """{}""" ;
     form:displayType displayTypes:numericalInput ;
+    form:validations
+      [ a form:PositiveNumber ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Het percentage moet groter zijn dan 0."@nl;
+        sh:path ext:involvementPercentage] ;
     sh:group ext:mainPg .
 
 ##########################################################

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -1,0 +1,98 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix schema: <http://schema.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+##########################################################
+# form
+##########################################################
+ext:form a form:Form, form:TopLevelForm ;
+    form:includes ext:administrativeUnitsL.
+
+##########################################################
+#  property-group
+##########################################################
+ext:mainPg a form:PropertyGroup;
+    sh:name "Bewerk betrokken lokale besturen" ;
+    sh:order 1 .
+
+##########################################################
+#  listing-scope: administrativeUnit
+##########################################################
+ext:administrativeUnitListingS a form:Scope;
+  sh:path ext:administrativeUnit.
+
+##########################################################
+#  Listing: Administrative unit
+##########################################################
+ext:administrativeUnitsL a form:Listing;
+  a form:ListingTable;
+  form:each ext:administrativeUnitFormItem;
+  form:scope ext:administrativeUnitListingS;
+  form:createGenerator ext:administrativeUnitGenerator;
+  form:canAdd true;
+  form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
+  form:canRemove true;
+  form:removeLabel "Verwijder";
+  sh:group ext:mainPg;
+  sh:order 2 .
+
+##########################################################
+#  Subform: administrativeUnit
+##########################################################
+ext:administrativeUnitFormItem a form:SubForm;
+   # sh:name "Betrokken lokale besturen" ;
+   form:includes ext:administrativeUnitNameF;
+   form:includes ext:administrativeUnitTypeOfInvolvementF;
+   form:includes ext:administrativeUnitInvolvementPercentageF;
+   form:hasFieldGroup ext:mainPg.
+
+##########################################################
+# Field: administrativeUnit name
+##########################################################
+ext:administrativeUnitNameF a form:Field ;
+    sh:name "Naam" ;
+    sh:order 1 ;
+    sh:path ext:name ;
+    form:options """{"conceptScheme":"http://example.concept/concept-schemes/administrative-units","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group ext:mainPg .
+
+##########################################################
+# Field: type of involvement
+##########################################################
+ext:administrativeUnitTypeOfInvolvementF a form:Field ;
+    sh:name "Type betrokkenheid" ;
+    sh:order 2 ;
+    sh:path ext:typeOfInvolvement ;
+    form:options """{"conceptScheme":"http://example.concept/concept-schemes/type-of-involvement","searchEnabled":false}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group ext:mainPg .
+
+##########################################################
+# Field: involvement percentage
+##########################################################
+ext:administrativeUnitInvolvementPercentageF a form:Field ;
+    sh:name "Financieel percentage" ;
+    form:help "Het totaal van alle percentages moet gelijk zijn aan 100";
+    sh:order 3;
+    sh:path ext:involvementPercentage;
+    form:options """{}""" ;
+    form:displayType displayTypes:numericalInput ;
+    sh:group ext:mainPg .
+
+##########################################################
+#  Generator: administrativeUnit
+##########################################################
+ext:administrativeUnitGenerator a form:Generator;
+  form:prototype [
+    form:shape [
+      a ext:AdministrativeUnit ;
+      ext:involvementPercentage 0
+    ]
+  ];
+  form:dataGenerator form:addMuUuid.

--- a/tests/dummy/public/test-forms/tables/meta.ttl
+++ b/tests/dummy/public/test-forms/tables/meta.ttl
@@ -1,0 +1,49 @@
+# Lokale besturen
+<http://example.concept/concept-schemes/administrative-units>
+    a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21d1250c-6627-4111-934f-f2f7bd8c078a" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Administrative units"@en.
+
+<http://example.concept/concepts/brugge>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672628" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/administrative-units>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Brugge (Gemeente)".
+
+<http://example.concept/concepts/antwerpen>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672621" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/administrative-units>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Antwerpen (Provincie)".
+
+<http://example.concept/concepts/lokeren>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672622" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/administrative-units>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Lokeren (Gemeente)".
+
+
+
+# Type betrokkenheid
+<http://example.concept/concept-schemes/type-of-involvement>
+    a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21d1250c-6627-4111-934f-f2f7bd8c078a" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Type betrokkenheid"@en.
+
+<http://example.concept/concepts/mede-financierend>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672628" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/type-of-involvement>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Mede-financierend".
+
+<http://example.concept/concepts/adviserend>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672621" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/type-of-involvement>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Adviserend".
+
+<http://example.concept/concepts/toezichthoudend>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672622" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://example.concept/concept-schemes/type-of-involvement>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Toezichthoudend".


### PR DESCRIPTION
This change allows us to display listings as a table instead of a list of blocks.

I added an example table that mimics the [Figma design](https://www.figma.com/file/DsCBi6M992vosTZAQ1LyzL/formbuilder?node-id=0%3A1&t=LBy2tDq6jeVvuXdr-0) and looks like this:

![image](https://user-images.githubusercontent.com/3533236/201959017-0aace04e-ba40-4861-a4d3-e21112474d49.png)
