### PR TITLE
Add support for Appuniversum v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.10.0",
+    "@appuniversum/ember-appuniversum": "^1.10.0 || ^2.0.0",
     "ember-data": "^3.16.0 || ^4.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.10.0",
+    "@appuniversum/ember-appuniversum": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@embroider/test-setup": "^1.0.0",


### PR DESCRIPTION
ember-appuniversum recently released a [v2 release](https://github.com/appuniversum/ember-appuniversum/releases/tag/v2.0.0) that didn't have any breaking API changes, so we can safely allow it as a peerDependency without any other code changes.