### PR TITLE
Fix an exception in the VlabelOpcentiem component

### DIFF
--- a/addon/components/rdf-input-fields/vlabel-opcentiem.js
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.js
@@ -40,7 +40,7 @@ export default class RdfInputFieldsVlabelOpcentiemComponent extends InputFieldCo
   amountColumnId = 'amount-column-' + guidFor(this);
 
   @tracked taxRateSubject = null;
-  @tracked taxEntries;
+  @tracked taxEntries = [];
   @tracked differentiatie = false;
 
   constructor() {


### PR DESCRIPTION
#107 introduced a regression in the VlabelOpcentiem component.

This ensures `taxEntries` is always an array, even if there is no data in the form graph. This ensures no exception is thrown when rendering the component.