### PR TITLE
Date display type changes

### DIFF
--- a/addon/components/rdf-input-fields/date-picker.hbs
+++ b/addon/components/rdf-input-fields/date-picker.hbs
@@ -1,0 +1,29 @@
+<AuLabel
+  @error={{this.hasErrors}}
+  @required={{this.isRequired}}
+  for={{this.inputId}}
+>
+  {{@field.label}}
+</AuLabel>
+<div class="au-o-grid au-o-grid--flush">
+  <div class="au-o-grid__item au-u-3-4">
+    <AuDatePicker
+      @id={{this.inputId}}
+      @error={{this.hasErrors}}
+      @value={{this.value}}
+      @onChange={{this.updateValue}}
+      @disabled={{@show}}
+      {{! TODO: This uses "private" apis since AuDatePicker doesn't support a blur event yet }}
+      {{on "duetBlur" (fn (mut this.hasBeenFocused) true)}}
+    />
+  </div>
+</div>
+
+{{#unless @show}}
+  <AuHelpText @error={{this.hasErrors}}>
+    Datum formaat: DD-MM-JJJJ
+  </AuHelpText>
+{{/unless}}
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+{{/each}}

--- a/addon/components/rdf-input-fields/date-picker.js
+++ b/addon/components/rdf-input-fields/date-picker.js
@@ -1,0 +1,15 @@
+import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
+import { XSD } from '@lblod/submission-form-helpers';
+import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import { literal } from 'rdflib';
+
+export default class RdfInputFieldsDatePickerComponent extends SimpleInputFieldComponent {
+  inputId = 'date-' + guidFor(this);
+
+  @action
+  updateValue(isoDate) {
+    const newDate = isoDate ? literal(isoDate, XSD('date')) : null;
+    super.updateValue(newDate);
+  }
+}

--- a/addon/components/rdf-input-fields/date.hbs
+++ b/addon/components/rdf-input-fields/date.hbs
@@ -7,14 +7,13 @@
 </AuLabel>
 <div class="au-o-grid au-o-grid--flush">
   <div class="au-o-grid__item au-u-3-4">
-    <AuDatePicker
-      @id={{this.inputId}}
+    <AuDateInput
       @error={{this.hasErrors}}
       @value={{this.value}}
       @onChange={{this.updateValue}}
       @disabled={{@show}}
-      {{! TODO: This uses "private" apis since AuDatePicker doesn't support a blur event yet }}
-      {{on "duetBlur" (fn (mut this.hasBeenFocused) true)}}
+      id={{this.inputId}}
+      {{on "blur" (fn (mut this.hasBeenFocused) true)}}
     />
   </div>
 </div>

--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -10,6 +10,7 @@ import ConceptSchemeSelectorComponent from '@lblod/ember-submission-form-fields/
 import ConceptSchemeMultiSelectorComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-multi-selector';
 import ConceptSchemeMultiSelectCheckboxesComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-multi-select-checkboxes';
 import DateComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date';
+import DatePickerComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-picker';
 import DateTimeComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-time';
 import FilesComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/files';
 import InputComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input';
@@ -170,6 +171,10 @@ registerComponentsForDisplayType([
   {
     displayType: 'http://lblod.data.gift/display-types/date',
     edit: DateComponent,
+  },
+  {
+    displayType: 'http://lblod.data.gift/display-types/datePicker',
+    edit: DatePickerComponent,
   },
   {
     displayType: 'http://lblod.data.gift/display-types/dateTime',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,7 @@ module.exports = function (defaults) {
     // Add options here
     '@appuniversum/ember-appuniversum': {
       dutchDatePickerLocalization: true,
+      disableWormholeElement: true,
     },
   };
 

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.10.0 || ^2.0.0",
+    "@appuniversum/ember-appuniversum": "^2.3.0",
     "ember-data": "^3.16.0 || ^4.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.0.0",
+    "@appuniversum/ember-appuniversum": "^2.3.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^1.8.3",

--- a/tests/dummy/public/test-forms/basic-fields/data.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/data.ttl
@@ -30,6 +30,10 @@
 <http://ember-submission-form-fields/source-node> <http://mu.semte.ch/vocabularies/ext/dateValue>
     "2022-12-06"^^<http://www.w3.org/2001/XMLSchema#date>.
 
+# Date picker
+<http://ember-submission-form-fields/source-node> <http://mu.semte.ch/vocabularies/ext/datePickerValue>
+    "2022-02-08"^^<http://www.w3.org/2001/XMLSchema#date>.
+
 # Date and time
 <http://ember-submission-form-fields/source-node> <http://mu.semte.ch/vocabularies/ext/dateTimeValue>
     "2022-12-31T23:00:00.000Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>.

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -162,6 +162,18 @@ ext:dateField a form:Field ;
 ext:mainFg form:hasField ext:dateField .
 
 ##########################################################
+# Date picker
+##########################################################
+ext:datePickerField a form:Field ;
+    sh:name "Datepicker" ;
+    sh:order 241 ;
+    sh:path ext:datePickerValue ;
+    form:displayType displayTypes:datePicker ;
+    sh:group ext:mainPg .
+
+ext:mainFg form:hasField ext:datePickerField .
+
+##########################################################
 # Date and time
 ##########################################################
 ext:dateTimeField a form:Field ;

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -153,7 +153,7 @@ ext:mainFg form:hasField ext:textAreaField .
 # Date
 ##########################################################
 ext:dateField a form:Field ;
-    sh:name "Datepicker" ;
+    sh:name "Date" ;
     sh:order 240 ;
     sh:path ext:dateValue ;
     form:displayType displayTypes:date ;


### PR DESCRIPTION
We now use the `AuDateInput` component for the `date` display type since this is generally the more user-friendly option. We also added a new `datePicker` display type with the original implementation so we can still use it if needed.