### PR TITLE
Use `@value` argument for the `<AuInput>` component

### DIFF
--- a/addon/components/rdf-input-fields/search.hbs
+++ b/addon/components/rdf-input-fields/search.hbs
@@ -4,7 +4,7 @@
 <AuInput
   @width="block"
   @disabled={{@show}}
-  value={{this.value}}
+  @value={{this.value}}
   id={{this.inputId}}
   class="au-u-margin-bottom-tiny"
   {{on "input" (perform this.search)}}


### PR DESCRIPTION
This fixes the issue where the value wasn't being prefilled in Ember 3.28 apps.

`<AuInput>` still uses `<Input>` internally which requires the value to be passed as `@value` in Ember 3.27+. Passing the value through an attribute is no longer supported and the value will be ignored.