### PR TITLE
Resolve `.firstObject` deprecations on newer Ember Data versions

### DIFF
--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -97,7 +97,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
         'filter[:uri:]': uri.value,
         page: { size: 1 },
       });
-      const file = files.get('firstObject');
+      const file = files.slice()[0]; // TODO: remove .slice once we support only Ember Data 4.8+
       if (file) return new FileField({ record: file, errors: [] });
       else
         return new FileField({

--- a/addon/components/rdf-input-fields/remote-urls/show.js
+++ b/addon/components/rdf-input-fields/remote-urls/show.js
@@ -56,7 +56,7 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends InputFieldCo
       page: { size: 1 },
     });
     if (remoteUrls.length) {
-      return remoteUrls.firstObject;
+      return remoteUrls.slice()[0]; // TODO: remove .slice once we support only Ember Data 4.8+
     } else {
       throw `No remote-url could be found for ${remoteObjectUri}`;
     }


### PR DESCRIPTION
Ember Data deprecated accessing non-array methods and properties on RecordArrays. The issue is that array[index] access doesn't work in older Ember Data versions. As a workaround we use `.slice()` first since it works in both old and new Ember data versions. In the future we can remove the `.slice()` call once older version support is dropped.