### PR TITLE
Add an option to display the row index in the listing table

### DIFF
--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -9,6 +9,9 @@
     </:title>
     --}}
     <:header>
+      {{#if this.showRowIndex}}
+        <th>{{! index }}</th>
+      {{/if}}
       {{#each this.tableHeaders as |column|}}
         <th>
           {{column.label}}
@@ -30,7 +33,7 @@
       {{/if}}
     </:header>
     <:body>
-      {{#each @subForms as |subForm|}}
+      {{#each @subForms as |subForm index|}}
         <this.ListingTableRow
           @subForm={{subForm}}
           @formStore={{@formStore}}
@@ -41,6 +44,8 @@
           @onRemoveEntry={{@removeEntry}}
           @canRemove={{this.canRemove}}
           @removeLabel={{@listing.removeLabel}}
+          @showIndex={{this.showRowIndex}}
+          @index={{index}}
         />
       {{else}}
         <tr>

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -10,7 +10,7 @@
     --}}
     <:header>
       {{#if this.showRowIndex}}
-        <th>{{! index }}</th>
+        <th>{{if this.indexLabel this.indexLabel}}</th>
       {{/if}}
       {{#each this.tableHeaders as |column|}}
         <th>

--- a/addon/components/listing/table.js
+++ b/addon/components/listing/table.js
@@ -30,6 +30,14 @@ export default class ListingTableComponent extends Component {
       sourceNode: listingTableNode,
     });
     this.tableHeaders = this.getTableHeaders(fields);
+
+    this.showRowIndex =
+      store.any(
+        listingTableNode,
+        FORM('showTableRowIndex'),
+        undefined,
+        graphs.formGraph
+      )?.value || false;
   }
 
   getTableTitle(tableForm) {

--- a/addon/components/listing/table.js
+++ b/addon/components/listing/table.js
@@ -38,6 +38,15 @@ export default class ListingTableComponent extends Component {
         undefined,
         graphs.formGraph
       )?.value || false;
+
+    if (this.showRowIndex) {
+      this.indexLabel = store.any(
+        listingTableNode,
+        FORM('tableIndexLabel'),
+        undefined,
+        graphs.formGraph
+      )?.value;
+    }
   }
 
   getTableTitle(tableForm) {

--- a/addon/components/listing/table/row.hbs
+++ b/addon/components/listing/table/row.hbs
@@ -1,4 +1,9 @@
 <tr ...attributes>
+  {{#if @showIndex}}
+    <td>
+      {{this.index}}
+    </td>
+  {{/if}}
   {{#each this.fields as |field|}}
     {{#let
       (component-for-display-type field.displayType show=@show)

--- a/addon/components/listing/table/row.js
+++ b/addon/components/listing/table/row.js
@@ -24,4 +24,8 @@ export default class ListingTableRow extends Component {
       node,
     });
   }
+
+  get index() {
+    return this.args.index + 1;
+  }
 }

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -38,6 +38,7 @@ ext:administrativeUnitsL a form:Listing;
   form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
   form:canRemove true;
   form:removeLabel "Verwijder";
+  form:showTableRowIndex true;
   sh:group ext:mainPg;
   sh:order 2 .
 

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -38,6 +38,7 @@ ext:administrativeUnitsL a form:Listing;
   form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
   form:canRemove true;
   form:removeLabel "Verwijder";
+  form:tableIndexLabel "#";
   form:showTableRowIndex true;
   sh:group ext:mainPg;
   sh:order 2 .


### PR DESCRIPTION
This adds a new `form:showTableRowIndex` predicate which can be used to display the row number as an extra column in the front of the table.

![image](https://user-images.githubusercontent.com/3533236/228199808-f53fe54e-7279-4d13-aa8b-6c14bcdae4d3.png)

`form:tableIndexLabel` can be used to set a specific string as the column header text.