### PR TITLE
Appuniversum "control" component improvements

### DIFF
--- a/addon/components/rdf-input-fields/checkbox.hbs
+++ b/addon/components/rdf-input-fields/checkbox.hbs
@@ -1,17 +1,20 @@
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{this.isRequired}}
-  for={{this.inputId}}
->
-  {{!TODO: use something else than a label. It's weird to use a label without content}}
-</AuLabel>
-<AuControlCheckbox
-  @identifier={{this.inputId}}
-  @label={{@field.label}}
+{{#if (or this.hasErrors this.isRequired)}}
+  <div class="au-u-margin-bottom-small">
+    {{#if this.hasErrors}}
+      <AuBadge @icon="cross" @skin="error" @size="small" />
+    {{/if}}
+    {{#if this.isRequired}}
+      <AuPill>Verplicht</AuPill>
+    {{/if}}
+  </div>
+{{/if}}
+<AuCheckbox
+  @checked={{this.value}}
   @disabled={{@show}}
   @onChange={{this.updateValue}}
-  @checked={{this.value}}
-/>
+>
+  {{@field.label}}
+</AuCheckbox>
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
 {{/each}}

--- a/addon/components/rdf-input-fields/checkbox.js
+++ b/addon/components/rdf-input-fields/checkbox.js
@@ -1,13 +1,10 @@
 import { action } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 
 // Note : default values are not working yet with this component, loadProvidedValue is overriden
 
 export default class RdfInputFieldsCheckboxComponent extends SimpleInputFieldComponent {
-  inputId = 'checkbox-' + guidFor(this);
-
   loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
@@ -1,33 +1,33 @@
-{{! TODO: Replace this with a fieldset + legend: https://github.com/appuniversum/ember-appuniversum/issues/210 }}
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{this.isRequired}}
-  for={{this.inputId}}
->
-  {{@field.label}}
-</AuLabel>
-
-<div id={{this.inputId}} class="au-o-grid au-o-grid--flush">
-  {{#each this.options as |option|}}
-    <div
-      class="au-o-grid__item
-        {{if
-          this.isColumnLayout
-          'au-u-1-1@tiny au-u-1-2@small au-u-1-3@medium'
-        }}"
-    >
-      <AuControlCheckbox
-        @identifier="{{this.inputId}}/{{@field.uri}}/<{{option.subject.value}}"
-        @name={{@field.uri.value}}
-        @label={{option.label}}
-        @value={{option.label}}
-        @onChange={{fn this.updateValue option}}
-        @disabled={{@show}}
-        @checked={{option.provided}}
-      />
+<AuFieldset as |f|>
+  <f.legend
+    @required={{this.isRequired}}
+    @requiredLabel={{this.requiredLabel}}
+    @error={{this.hasErrors}}
+  >
+    {{@field.label}}
+  </f.legend>
+  <f.content class="concept-scheme-multi-select-checkboxes__content">
+    <div class="au-o-grid au-o-grid--flush">
+      {{#each this.options as |option|}}
+        <div
+          class="au-o-grid__item
+            {{if
+              this.isColumnLayout
+              "au-u-1-1@tiny au-u-1-2@small au-u-1-3@medium"
+            }}"
+        >
+          <AuCheckbox
+            @name={{@field.uri.value}}
+            @value={{option.label}}
+            @onChange={{fn this.updateValue option}}
+            @disabled={{@show}}
+            @checked={{option.provided}}
+          >{{option.label}}</AuCheckbox>
+        </div>
+      {{/each}}
     </div>
-  {{/each}}
-</div>
+  </f.content>
+</AuFieldset>
 
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -1,5 +1,4 @@
 import { action } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import {
@@ -11,8 +10,6 @@ import {
 import { namedNode } from 'rdflib';
 
 export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent extends InputFieldComponent {
-  inputId = 'multi-select-checkboxes-' + guidFor(this);
-
   @tracked options = [];
 
   constructor() {

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
@@ -1,28 +1,23 @@
-{{! TODO Use a <fieldset> and <legend> combo to group radio buttons
-    More information: https://github.com/appuniversum/ember-appuniversum/issues/210
-}}
-<AuLabel
-  @error={{this.hasErrors}}
-  @required={{this.isRequired}}
-  for={{this.inputId}}
->
-  {{@field.label}}
-</AuLabel>
-<ul id={{this.inputId}}>
-  {{#each this.options as |option|}}
-    <li>
-      <AuControlRadio
-        @identifier="{{@field.uri}}/<{{option.value}}"
-        @name={{@field.uri.value}}
-        @label={{option.label}}
-        @value={{option.label}}
-        @onChange={{fn this.updateValue option}}
-        @disabled={{@show}}
-        checked={{eq this.value option.value}}
-      />
-    </li>
-  {{/each}}
-</ul>
+<AuFieldset as |f|>
+  <f.legend @required={{this.isRequired}} @error={{this.hasErrors}}>
+    {{@field.label}}
+  </f.legend>
+  <f.content>
+    <ul>
+      {{#each this.options as |option|}}
+        <li>
+          <AuRadio
+            @name={{@field.uri.value}}
+            @value={{option.label}}
+            @onChange={{fn this.updateValue option}}
+            @disabled={{@show}}
+            @checked={{eq this.value option.value}}
+          >{{option.label}}</AuRadio>
+        </li>
+      {{/each}}
+    </ul>
+  </f.content>
+</AuFieldset>
 
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -1,13 +1,10 @@
 import { action } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { SKOS } from '@lblod/submission-form-helpers';
 import { namedNode } from 'rdflib';
 
 export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends SimpleInputFieldComponent {
-  inputId = 'concept-scheme-radio-buttons-' + guidFor(this);
-
   @tracked options = [];
 
   constructor() {

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
@@ -3,12 +3,13 @@
 </AuLabel>
 
 {{#if this.showDifferentiatie}}
-  <AuControlCheckbox
-    @label="Vink aan indien er sprake is van differentiatie"
+  <AuCheckbox
     @onChange={{this.toggleDifferentiatie}}
     @disabled={{@show}}
     @checked={{this.differentiatie}}
-  />
+  >
+    Vink aan indien er sprake is van differentiatie
+  </AuCheckbox>
 {{else}}
   <AuHelpText>
     {{#if @show}}

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -2,3 +2,10 @@
 .listing-table td {
   vertical-align: top;
 }
+
+/* Can be removed once Appuniversum adds this by default, or removes the flex from the default version:
+   https://github.com/appuniversum/ember-appuniversum/blob/8793c19fbd69e9a1cec2ed5c670efef4bd77b21d/app/styles/ember-appuniversum/_c-fieldset.scss#L49-L52C23
+*/
+.concept-scheme-multi-select-checkboxes__content {
+  width: 100%;
+}

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.3.0",
+    "@appuniversum/ember-appuniversum": "^2.5.0",
     "ember-data": "^3.16.0 || ^4.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.3.0",
+    "@appuniversum/ember-appuniversum": "^2.5.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",


### PR DESCRIPTION
- Use the new `AuRadio` and `AuCheckbox` components since the others are now deprecated
- Use `AuFieldset` where needed since this is the correct way to label a group of inputs