### PR TITLE
Remove ensure-safe-component

### DIFF
--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -53,8 +53,8 @@
             @show={{@show}}/>
         {{else}}
           <div class="au-u-margin-bottom-small">
-            {{#let (ensure-safe-component
-              (component-for-display-type field.displayType show=@show))
+            {{#let
+              (component-for-display-type field.displayType show=@show)
               as |FormField|
             }}
               <FormField

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -10,8 +10,8 @@
     {{#each this.fields as |field|}}
       {{#if field.displayType}}
         <li class="au-o-grid__item au-u-1-1">
-          {{#let (ensure-safe-component
-            (component-for-display-type field.displayType show=@show))
+          {{#let
+            (component-for-display-type field.displayType show=@show)
             as |FormField|
           }}
             <FormField

--- a/package.json
+++ b/package.json
@@ -90,10 +90,6 @@
     "sass": "^1.49.8",
     "webpack": "^5.74.0"
   },
-  "overrides": {
-    "@embroider/macros": "^1.6.0",
-    "@embroider/util": "^1.6.0"
-  },
   "engines": {
     "node": "14.* || 16.* || >= 18"
   },


### PR DESCRIPTION
This was only needed to support Ember < 3.25, but we dropped support for those in v2.

It seems we also didn't include `@embroider/util` as a dependency so this only worked because a nested dependency brought it in 😬 .