### PR TITLE
Update Ember Data to 4.12.0

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -37,7 +37,22 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
-    packageRules: [{ '@ember-data/store': null }],
+    packageRules: [
+      {
+        package: '@ember-data/store',
+        addonModules: {
+          '-private.js': {
+            dependsOnModules: [],
+          },
+          '-private/system/core-store.js': {
+            dependsOnModules: [],
+          },
+          '-private/system/model/internal-model.js': {
+            dependsOnModules: [],
+          },
+        },
+      },
+    ],
     compatAdapters,
   });
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,6 +20,16 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
+  // The built-in compat adapters for Ember Data shouldn't be needed anymore.
+  // This code can be removed once https://github.com/embroider-build/embroider/pull/1369 is released.
+  const compatAdapters = new Map();
+  compatAdapters.set('ember-data', null);
+  compatAdapters.set('@ember-data/adapter', null);
+  compatAdapters.set('@ember-data/model', null);
+  compatAdapters.set('@ember-data/record-data', null);
+  compatAdapters.set('@ember-data/serializer', null);
+  compatAdapters.set('@ember-data/store', null);
+
   const { maybeEmbroider } = require('@embroider/test-setup');
   return maybeEmbroider(app, {
     skipBabel: [
@@ -27,5 +37,7 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
+    packageRules: [{ '@ember-data/store': null }],
+    compatAdapters,
   });
 };

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-data": "^4.8.0",
+    "ember-data": "~4.12.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
-    "@embroider/test-setup": "^1.8.3",
+    "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
It seems we were using a wide version range for Ember Data and the last release made the Embroider builds fail if the built-in packageRules and adapters weren't disabled.

This change updates Ember Data to 4.12 and disables the compat adapters and packageRules. Once a new version of `@embroider/compat` we can remove the config again.