### PR TITLE
Listing layout improvements

### DIFF
--- a/addon/components/listing.hbs
+++ b/addon/components/listing.hbs
@@ -11,5 +11,6 @@
   @createEntry={{this.createEntry}}
   @listing={{@listing}}
   @sourceNode={{@sourceNode}}
+  @useNewListingLayout={{@useNewListingLayout}}
   ...attributes
 />

--- a/addon/components/listing.hbs
+++ b/addon/components/listing.hbs
@@ -11,4 +11,5 @@
   @createEntry={{this.createEntry}}
   @listing={{@listing}}
   @sourceNode={{@sourceNode}}
+  ...attributes
 />

--- a/addon/components/listing/list.hbs
+++ b/addon/components/listing/list.hbs
@@ -1,5 +1,5 @@
-<div class="au-o-grid">
-  <div class="au-o-grid__item au-u-4-5">
+{{#if @useNewListingLayout}}
+  <div class="au-o-flow" ...attributes>
     {{#each @subForms as |subForm index|}}
       <SubForm
         @subForm={{subForm}}
@@ -13,20 +13,54 @@
         @level={{@level}}
         @onRemoveEntry={{@removeEntry}}
         @canRemove={{@canRemove}}
+        @useNewListingLayout={{true}}
       />
     {{/each}}
-  </div>
-  {{#if @canAdd}}
-    <div class="au-o-grid__item au-u-1-5">
+
+    {{#if @canAdd}}
       <AuButton
         @icon="plus"
+        @skin="secondary"
+        @width="block"
         @iconAlignment="left"
-        class="au-u-margin-bottom-tiny"
         @disabled={{@creationFormData}}
         {{on "click" @createEntry}}
       >
         {{@listing.addLabel}}
       </AuButton>
+    {{/if}}
+  </div>
+{{else}}
+  <div class="au-o-grid">
+    <div class="au-o-grid__item au-u-4-5">
+      {{#each @subForms as |subForm index|}}
+        <SubForm
+          @subForm={{subForm}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{subForm.sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @last={{eq index (sub @subForms.length 1)}}
+          @show={{@show}}
+          @level={{@level}}
+          @onRemoveEntry={{@removeEntry}}
+          @canRemove={{@canRemove}}
+        />
+      {{/each}}
     </div>
-  {{/if}}
-</div>
+    {{#if @canAdd}}
+      <div class="au-o-grid__item au-u-1-5">
+        <AuButton
+          @icon="plus"
+          @iconAlignment="left"
+          class="au-u-margin-bottom-tiny"
+          @disabled={{@creationFormData}}
+          {{on "click" @createEntry}}
+        >
+          {{@listing.addLabel}}
+        </AuButton>
+      </div>
+    {{/if}}
+  </div>
+{{/if}}

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -1,4 +1,4 @@
-<div ...attributes>
+<div class="au-u-margin-bottom" ...attributes>
   <AuTable class="listing-table">
     {{! TODO: Named blocks can't be rendered conditionally yet, so we would have to duplicate the component and all the other blocks as a workaround.
         Since the title is only a "nice to have" we'll disable it for now until a better solution is found.

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -1,4 +1,4 @@
-<div class="au-u-margin-bottom" ...attributes>
+<div ...attributes>
   <AuTable class="listing-table">
     {{! TODO: Named blocks can't be rendered conditionally yet, so we would have to duplicate the component and all the other blocks as a workaround.
         Since the title is only a "nice to have" we'll disable it for now until a better solution is found.

--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -1,5 +1,5 @@
 {{#if this.children}}
-  <div ...attributes>
+  <div class={{if @useNewListingLayout "au-o-flow"}} ...attributes>
     {{#if this.showTitleBlock}}
       <div class="au-u-margin-bottom-small">
         {{#if @group.name}}
@@ -33,7 +33,9 @@
             @sourceNode={{@sourceNode}}
             @forceShowErrors={{@forceShowErrors}}
             @cacheConditionals={{@cacheConditionals}}
-            @show={{@show}}/>
+            @show={{@show}}
+            @useNewListingLayout={{@useNewListingLayout}}
+          />
           {{#if @last}}
             {{#if (not-eq index (sub this.children.length 1))}}
               <AuHr @size="large"/>
@@ -50,7 +52,9 @@
             @sourceNode={{@sourceNode}}
             @forceShowErrors={{@forceShowErrors}}
             @cacheConditionals={{@cacheConditionals}}
-            @show={{@show}}/>
+            @show={{@show}}
+            @useNewListingLayout={{@useNewListingLayout}}
+          />
         {{else}}
           <div class="au-u-margin-bottom-small">
             {{#let

--- a/addon/components/property-group.hbs
+++ b/addon/components/property-group.hbs
@@ -69,8 +69,10 @@
               />
             {{/let}}
 
-            {{! template-lint-disable no-triple-curlies}}
-            <AuHelpText>{{{field.help}}}</AuHelpText>
+            {{#if field.help}}
+              {{! template-lint-disable no-triple-curlies}}
+              <AuHelpText>{{{field.help}}}</AuHelpText>
+            {{/if}}
           </div>
         {{/if}}
       {{/if}}

--- a/addon/components/rdf-form.hbs
+++ b/addon/components/rdf-form.hbs
@@ -11,6 +11,8 @@
       @cacheConditionals={{@cacheConditionals}}
       @last={{eq index (sub this.propertyGroups.length 1)}}
       @show={{@show}}
-      @level={{@level}}/>
+      @level={{@level}}
+      @useNewListingLayout={{@useNewListingLayout}} {{!Temporary argument so we don't break the css hacks in the LPDC module}}
+    />
   {{/each}}
 </div>

--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -1,38 +1,86 @@
-{{#if @subForm.itemLabel}}
-  <div class="au-u-margin-bottom-small">
-    <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
-      {{@subForm.itemLabel}}
-    </AuHeading>
-  </div>
-{{/if}}
+{{#if @useNewListingLayout}}
+  <div class="sf-listing-sub-form au-o-box">
+    {{#if (or @subForm.itemLabel @canRemove)}}
+      <AuToolbar @size={{this.size}} as |Group|>
+        <Group>
+          {{#if @subForm.itemLabel}}
+            {{! TODO: The args are undefined so the heading always defaults to a h1 }}
+            <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
+              {{@subForm.itemLabel}}
+            </AuHeading>
+          {{/if}}
+        </Group>
+        {{#if @canRemove}}
+          <Group>
+            <AuButton
+              @skin="naked"
+              @icon="bin"
+              @iconAlignment="left"
+              @alert={{true}}
+              {{on "click" (fn @onRemoveEntry @sourceNode)}}
+            >
+              {{@subForm.removeLabel}}
+            </AuButton>
+          </Group>
+        {{/if}}
+      </AuToolbar>
+    {{/if}}
 
-<div class="au-o-grid">
-  <div class="au-o-flow au-o-grid__item au-u-4-5">
-    {{#each this.propertyGroups as |group index|}}
-      <PropertyGroup
-        @form={{@subForm.uri}}
-        @group={{group}}
-        @formStore={{@formStore}}
-        @graphs={{@graphs}}
-        @sourceNode={{@sourceNode}}
-        @forceShowErrors={{@forceShowErrors}}
-        @cacheConditionals={{@cacheConditionals}}
-        @last={{eq index (sub this.propertyGroups.length 1)}}
-        @show={{@show}}
-        @level={{@level}}/>
-    {{/each}}
+    <div class="au-o-flow">
+      {{#each this.propertyGroups as |group index|}}
+        <PropertyGroup
+          @form={{@subForm.uri}}
+          @group={{group}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{@sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @last={{eq index (sub this.propertyGroups.length 1)}}
+          @show={{@show}}
+          @level={{@level}}
+        />
+      {{/each}}
+    </div>
   </div>
-
-  {{#if @canRemove}}
-    <div class="au-o-grid__item au-u-1-5">
-      <AuButton
-        @skin="link"
-        @icon="bin"
-        @iconAlignment="left"
-        {{on "click" (fn  @onRemoveEntry @sourceNode)}}
-      >
-        {{@subForm.removeLabel}}
-      </AuButton>
+{{else}}
+  {{#if @subForm.itemLabel}}
+    <div class="au-u-margin-bottom-small">
+      <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
+        {{@subForm.itemLabel}}
+      </AuHeading>
     </div>
   {{/if}}
-</div>
+
+  <div class="au-o-grid">
+    <div class="au-o-flow au-o-grid__item au-u-4-5">
+      {{#each this.propertyGroups as |group index|}}
+        <PropertyGroup
+          @form={{@subForm.uri}}
+          @group={{group}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{@sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @last={{eq index (sub this.propertyGroups.length 1)}}
+          @show={{@show}}
+          @level={{@level}}
+        />
+      {{/each}}
+    </div>
+
+    {{#if @canRemove}}
+      <div class="au-o-grid__item au-u-1-5">
+        <AuButton
+          @skin="link"
+          @icon="bin"
+          @iconAlignment="left"
+          {{on "click" (fn @onRemoveEntry @sourceNode)}}
+        >
+          {{@subForm.removeLabel}}
+        </AuButton>
+      </div>
+    {{/if}}
+  </div>
+{{/if}}

--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -7,7 +7,7 @@
 {{/if}}
 
 <div class="au-o-grid">
-  <div class="au-o-grid__item au-u-4-5">
+  <div class="au-o-flow au-o-grid__item au-u-4-5">
     {{#each this.propertyGroups as |group index|}}
       <PropertyGroup
         @form={{@subForm.uri}}

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -11,6 +11,11 @@
   margin: 0; /* browsers add a 1px margin which looks strange when it's displayed next to other inputs */
 }
 
+.sf-listing-sub-form {
+  border: .1rem solid var(--au-gray-200);
+  border-radius: var(--au-radius);
+}
+
 /* Can be removed once Appuniversum adds this by default, or removes the flex from the default version:
    https://github.com/appuniversum/ember-appuniversum/blob/8793c19fbd69e9a1cec2ed5c670efef4bd77b21d/app/styles/ember-appuniversum/_c-fieldset.scss#L49-L52C23
 */

--- a/tests/dummy/app/components/test-form.hbs
+++ b/tests/dummy/app/components/test-form.hbs
@@ -6,4 +6,5 @@
   @formStore={{@formStore}}
   @show={{this.formConfig.isReadOnly}}
   @forceShowErrors={{@forceShowErrors}}
+  @useNewListingLayout={{true}}
 />


### PR DESCRIPTION
The listing component layout is pretty barebones. The only place where we used this used _a lot_ of CSS hacks to improve the styling.

We now want to use the listing in a different place but don't want to repeat the CSS hackery.

This adds some simple improvements to make it usable. We still want to let this go through the design team and update this properly in the future.

The new layout can be toggled [by setting `@useNewListingLayout={{true}}` on the RdfForm component](https://github.com/lblod/ember-submission-form-fields/pull/128/files#diff-5d74ab22d7a704ae8bbf3180923365306c604afbfd0d6e2b01a183e471b824e3R9). That way we ensure compatibility with the CSS hackery done for the old layout. We'll remove that in the next major release.

<details>
<summary>Before screenshot</summary>

![image](https://user-images.githubusercontent.com/3533236/231812147-a08f93b1-e49f-40cf-b54d-d551ecb4fc2e.png)
</details>

<details>
<summary>After screenshot</summary>

![image](https://user-images.githubusercontent.com/3533236/231808867-fd4d9dea-9b63-491c-8a14-a48e58d8501f.png)
</details>
