### PR TITLE
Fix the subform title levels

### DIFF
--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -4,7 +4,6 @@
       <AuToolbar @size={{this.size}} as |Group|>
         <Group>
           {{#if @subForm.itemLabel}}
-            {{! TODO: The args are undefined so the heading always defaults to a h1 }}
             <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
               {{@subForm.itemLabel}}
             </AuHeading>
@@ -38,7 +37,7 @@
           @cacheConditionals={{@cacheConditionals}}
           @last={{eq index (sub this.propertyGroups.length 1)}}
           @show={{@show}}
-          @level={{@level}}
+          @level={{this.nextLevel}}
         />
       {{/each}}
     </div>

--- a/addon/components/sub-form.js
+++ b/addon/components/sub-form.js
@@ -12,4 +12,21 @@ export default class SubFormComponent extends Component {
       form: this.args.subForm.uri,
     });
   }
+
+  get level() {
+    return this.args.level || 2;
+  }
+
+  get nextLevel() {
+    // We only want to increase the level of the nested titles if we display a title ourselves
+    return this.args.subForm.itemLabel ? this.level + 1 : this.level;
+  }
+
+  get titleLevel() {
+    return `${this.level}`;
+  }
+
+  get titleSkin() {
+    return `${this.level + 1}`;
+  }
 }


### PR DESCRIPTION
The previous implementation was always passing `undefined` to the heading component which resulted in a `h1` element and styling.