### PR TITLE
Add `sh:minCount` support to the listing component

### DIFF
--- a/addon/models/listing.js
+++ b/addon/models/listing.js
@@ -1,5 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { SHACL, FORM, RDF } from '@lblod/submission-form-helpers';
+import { Literal } from 'rdflib';
 
 export const LISTING_TYPE = 'http://lblod.data.gift/vocabularies/forms/Listing';
 
@@ -17,6 +18,15 @@ export default class ListingModel {
     this.rdflibScope = store.any(uri, FORM('scope'), undefined, formGraph);
     this.rdflibOptions = store.any(uri, FORM('options'), undefined, formGraph);
     this.rdflibCanAdd = store.any(uri, FORM('canAdd'), undefined, formGraph);
+    let rdflibMinCount = store.any(
+      uri,
+      SHACL('minCount'),
+      undefined,
+      formGraph
+    );
+    if (rdflibMinCount) {
+      this.minCount = Literal.toJS(rdflibMinCount);
+    }
     this.rdflibMaxCount = store.any(
       uri,
       SHACL('maxCount'),

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -37,6 +37,8 @@ ext:administrativeUnitsL a form:Listing;
   form:canAdd true;
   form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
   form:canRemove true;
+  sh:minCount 3;
+  sh:maxCount 10;
   form:removeLabel "Verwijder";
   form:tableIndexLabel "#";
   form:showTableRowIndex true;


### PR DESCRIPTION
Similar to `sh:maxCount`, this can be used to add a minimum requirement to the amount of listing items. If the data doesn't contain enough items we now pregenerate extra items until the minimum is reached.

This can be used to force users to enter a certain amount of data without having to use constraints.