### PR TITLE
Add a new alert field

### DIFF
--- a/addon/components/rdf-input-fields/alert.hbs
+++ b/addon/components/rdf-input-fields/alert.hbs
@@ -1,0 +1,10 @@
+<AuAlert
+  @title={{this.options.title}}
+  @icon={{this.options.icon}}
+  @closable={{this.options.closable}}
+  @size={{this.options.size}}
+  @skin={{this.options.skin}}
+  class="au-u-margin-bottom-none"
+>
+  {{@field.label}}
+</AuAlert>

--- a/addon/components/rdf-input-fields/alert.js
+++ b/addon/components/rdf-input-fields/alert.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class AlertComponent extends Component {
+  get options() {
+    return this.args.field.options;
+  }
+}

--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 
 // Basic fields
+import AlertComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/alert';
 import BestuursorgaanSelectorEditComponent from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/edit';
 import BestuursorgaanSelectorShowComponent from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/show';
 import CaseNumberComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/case-number';
@@ -13,6 +14,7 @@ import DateComponent from '@lblod/ember-submission-form-fields/components/rdf-in
 import DatePickerComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-picker';
 import DateTimeComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-time';
 import FilesComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/files';
+import HeadingComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/heading';
 import InputComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input';
 import NumericalInputComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/numerical-input';
 import PropertyGroupComponent from '@lblod/ember-submission-form-fields/components/property-group';
@@ -22,7 +24,7 @@ import RemoteUrlsShowComponent from '@lblod/ember-submission-form-fields/compone
 import SwitchComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/switch';
 import TextAreaComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/text-area';
 import VlabelOpcentiemComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/vlabel-opcentiem';
-import HeadingComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/heading';
+
 // Search components
 import SearchPanelFieldsSearchEditComponent from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/edit';
 import SearchPanelFieldsSearchShowComponent from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/show';
@@ -132,6 +134,10 @@ export function getComponentForDisplayType(displayType, show) {
 // Register all the built-in components
 registerComponentsForDisplayType([
   // Basic fields
+  {
+    displayType: 'http://lblod.data.gift/display-types/alert',
+    edit: AlertComponent,
+  },
   {
     displayType: 'http://lblod.data.gift/display-types/bestuursorgaanSelector',
     edit: BestuursorgaanSelectorEditComponent,

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -30,6 +30,19 @@ ext:mainPg a form:PropertyGroup;
     sh:order 1 .
 
 ##########################################################
+# Alert
+##########################################################
+ext:alertField a form:Field;
+    sh:name "Alert message";
+    sh:order 10;
+    form:options """{ "title": "Alert title", "skin": "warning", "icon": "alert-triangle", "size": "small", "closable": true }""";
+    form:displayType displayTypes:alert ;
+    form:help """This is a wrapper around the <a class="au-c-link" href="https://appuniversum.github.io/ember-appuniversum/?path=/story/components-notifications-aualert--component">AuAlert component</a> with similar configuration options""" ;
+    sh:group ext:mainPg.
+
+ext:mainFg form:hasField ext:alertField .
+
+##########################################################
 # Heading
 ##########################################################
 ext:headerField a form:Field;
@@ -48,7 +61,6 @@ ext:headerField a form:Field;
     sh:group ext:mainPg.
 
 ext:mainFg form:hasField ext:headerField .
-
 
 ##########################################################
 # Checkbox


### PR DESCRIPTION
This field can be used if extra messages need to be displayed inside the form.

![image](https://github.com/lblod/ember-submission-form-fields/assets/3533236/0f1719c2-f530-4e2b-be7f-6ff6c2bdc1c9)

The field can be configured through the `form:options` predicate:
https://github.com/lblod/ember-submission-form-fields/blob/5154d3d8742c862d1587783ecc618bcc6f12b338/tests/dummy/public/test-forms/basic-fields/form.ttl#L38

The `sh:name` will be used as the content for the AuAlert component (so in this example it is `sh:name "Alert message"`)