### PR TITLE
Widen dependency version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-auto-import": "^2.4.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
-    "ember-concurrency": "^2.0.0",
+    "ember-concurrency": "^2.0.0 || ^3.0.0",
     "ember-math-helpers": "^2.18.1",
     "ember-truth-helpers": "^3.0.0",
     "forking-store": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-page-title": "^7.0.0",
-    "ember-power-select": "^6.0.0",
+    "ember-power-select": "^7.0.0",
     "ember-qunit": "^6.0.0",
     "ember-resolver": "^8.0.3",
     "ember-source": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
     "ember-concurrency": "^2.0.0 || ^3.0.0",
-    "ember-math-helpers": "^2.18.1",
+    "ember-math-helpers": "^2.18.1 || v3.0.0",
     "ember-truth-helpers": "^3.0.0",
     "forking-store": "^2.0.0",
     "rdflib": "^2.2.19",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.5.0",
     "ember-data": "^3.16.0 || ^4.0.0",
-    "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
+    "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@lblod/submission-form-helpers": "^2.0.1",
-    "clipboardy": "^2.3.0",
+    "clipboardy": "^3.0.0",
     "ember-auto-import": "^2.4.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.5.0",
-    "ember-data": "^3.16.0 || ^4.0.0",
+    "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows consuming projects to use newer versions without it being a breaking change (or the projects to need overrides).