### PR TITLE
Allow ember-source v3 as well since we still support that

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@appuniversum/ember-appuniversum": "^2.6.0",
     "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "ember-source": "^4.0.0 || ^5.0.0"
+    "ember-source": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^2.5.0",


### PR DESCRIPTION
The version range was added in the blueprint update PR, but it wasn't adjusted for the range we support in the addon.