### PR TITLE
Remove ember-fetch

### DIFF
--- a/addon/components/rdf-input-fields/case-number.js
+++ b/addon/components/rdf-input-fields/case-number.js
@@ -3,7 +3,6 @@ import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import clipboardy from 'clipboardy';
-import fetch from 'fetch';
 
 /**
  *

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-data": "~4.12.0",
-    "ember-fetch": "^8.1.1",
     "ember-load-initializers": "^2.1.2",
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-page-title": "^7.0.0",


### PR DESCRIPTION
ember-fetch causes issues in strict Embroider apps because of the AMD magic it does behind the scenes.

All the browsers that we support also support native fetch. FastBoot apps should polyfill fetch if needed, and tests should patch native fetch so that the waiter system works for that.