### PR TITLE
Add a new reordering option to the listings

### DIFF
--- a/addon/components/listing.hbs
+++ b/addon/components/listing.hbs
@@ -8,6 +8,9 @@
   @removeEntry={{this.removeEntry}}
   @canAdd={{this.canAdd}}
   @canRemove={{this.canRemove}}
+  @canChangeOrder={{this.canChangeOrder}}
+  @moveUp={{this.moveUp}}
+  @moveDown={{this.moveDown}}
   @createEntry={{this.createEntry}}
   @listing={{@listing}}
   @sourceNode={{@sourceNode}}

--- a/addon/components/listing/list.hbs
+++ b/addon/components/listing/list.hbs
@@ -1,20 +1,26 @@
 {{#if @useNewListingLayout}}
   <div class="au-o-flow" ...attributes>
-    {{#each @subForms as |subForm|}}
-      <SubForm
-        @subForm={{subForm}}
-        @formStore={{@formStore}}
-        @graphs={{@graphs}}
-        @sourceNode={{subForm.sourceNode}}
-        @forceShowErrors={{@forceShowErrors}}
-        @cacheConditionals={{@cacheConditionals}}
-        @last={{this.isLast @subForms subForm}}
-        @show={{@show}}
-        @level={{@level}}
-        @onRemoveEntry={{@removeEntry}}
-        @canRemove={{@canRemove}}
-        @useNewListingLayout={{true}}
-      />
+    {{#each @subForms as |subForm index|}}
+      {{#let (eq index 0) (this.isLast @subForms subForm) as |isFirst isLast|}}
+        <SubForm
+          @subForm={{subForm}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{subForm.sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @last={{isLast}}
+          @show={{@show}}
+          @level={{@level}}
+          @onRemoveEntry={{@removeEntry}}
+          @canRemove={{@canRemove}}
+          @canMoveUp={{(and @canChangeOrder (not isFirst))}}
+          @canMoveDown={{(and @canChangeOrder (not isLast))}}
+          @moveUp={{fn @moveUp subForm}}
+          @moveDown={{fn @moveDown subForm}}
+          @useNewListingLayout={{true}}
+        />
+      {{/let}}
     {{/each}}
 
     {{#if @canAdd}}
@@ -33,20 +39,29 @@
 {{else}}
   <div class="au-o-grid">
     <div class="au-o-grid__item au-u-4-5">
-      {{#each @subForms as |subForm|}}
-        <SubForm
-          @subForm={{subForm}}
-          @formStore={{@formStore}}
-          @graphs={{@graphs}}
-          @sourceNode={{subForm.sourceNode}}
-          @forceShowErrors={{@forceShowErrors}}
-          @cacheConditionals={{@cacheConditionals}}
-          @last={{this.isLast @subForms subForm}}
-          @show={{@show}}
-          @level={{@level}}
-          @onRemoveEntry={{@removeEntry}}
-          @canRemove={{@canRemove}}
-        />
+      {{#each @subForms as |subForm index|}}
+        {{#let
+          (eq index 0) (this.isLast @subForms subForm)
+          as |isFirst isLast|
+        }}
+          <SubForm
+            @subForm={{subForm}}
+            @formStore={{@formStore}}
+            @graphs={{@graphs}}
+            @sourceNode={{subForm.sourceNode}}
+            @forceShowErrors={{@forceShowErrors}}
+            @cacheConditionals={{@cacheConditionals}}
+            @last={{this.isLast @subForms subForm}}
+            @show={{@show}}
+            @level={{@level}}
+            @onRemoveEntry={{@removeEntry}}
+            @canRemove={{@canRemove}}
+            @canMoveUp={{(and @canChangeOrder (not isFirst))}}
+            @canMoveDown={{(and @canChangeOrder (not isLast))}}
+            @moveUp={{fn @moveUp subForm}}
+            @moveDown={{fn @moveDown subForm}}
+          />
+        {{/let}}
       {{/each}}
     </div>
     {{#if @canAdd}}

--- a/addon/components/listing/order-button-group.hbs
+++ b/addon/components/listing/order-button-group.hbs
@@ -1,0 +1,22 @@
+<div class="sf-listing-order-button-group au-u-flex au-u-flex--column" ...attributes>
+  <AuButton
+    @skin="naked"
+    @icon="nav-up"
+    @hideText={{true}}
+    @disabled={{not @canMoveUp}}
+    class="sf-listing-order-button-group__button"
+    {{on "click" @moveUp}}
+  >
+    Naar boven verplaatsen
+  </AuButton>
+  <AuButton
+    @skin="naked"
+    @icon="nav-down"
+    @hideText={{true}}
+    @disabled={{not @canMoveDown}}
+    class="sf-listing-order-button-group__button"
+    {{on "click" @moveDown}}
+  >
+    Naar onder verplaatsen
+  </AuButton>
+</div>

--- a/addon/components/listing/table.hbs
+++ b/addon/components/listing/table.hbs
@@ -9,6 +9,9 @@
     </:title>
     --}}
     <:header>
+      {{#if @canChangeOrder}}
+        <th></th>
+      {{/if}}
       {{#if this.showRowIndex}}
         <th>{{if this.indexLabel this.indexLabel}}</th>
       {{/if}}
@@ -34,19 +37,28 @@
     </:header>
     <:body>
       {{#each @subForms as |subForm index|}}
-        <this.ListingTableRow
-          @subForm={{subForm}}
-          @formStore={{@formStore}}
-          @graphs={{@graphs}}
-          @sourceNode={{subForm.sourceNode}}
-          @forceShowErrors={{@forceShowErrors}}
-          @show={{@show}}
-          @onRemoveEntry={{@removeEntry}}
-          @canRemove={{this.canRemove}}
-          @removeLabel={{@listing.removeLabel}}
-          @showIndex={{this.showRowIndex}}
-          @index={{index}}
-        />
+        {{#let
+          (eq index 0) (this.isLast @subForms subForm)
+          as |isFirst isLast|
+        }}
+          <this.ListingTableRow
+            @subForm={{subForm}}
+            @formStore={{@formStore}}
+            @graphs={{@graphs}}
+            @sourceNode={{subForm.sourceNode}}
+            @forceShowErrors={{@forceShowErrors}}
+            @show={{@show}}
+            @onRemoveEntry={{@removeEntry}}
+            @canRemove={{this.canRemove}}
+            @removeLabel={{@listing.removeLabel}}
+            @showIndex={{this.showRowIndex}}
+            @index={{index}}
+            @canMoveUp={{(and @canChangeOrder (not isFirst))}}
+            @canMoveDown={{(and @canChangeOrder (not isLast))}}
+            @moveUp={{fn @moveUp subForm}}
+            @moveDown={{fn @moveDown subForm}}
+          />
+        {{/let}}
       {{else}}
         <tr>
           <td colspan="100%">{{@listing.noDataMessage}}</td>

--- a/addon/components/listing/table.js
+++ b/addon/components/listing/table.js
@@ -2,9 +2,11 @@ import Component from '@glimmer/component';
 import { SHACL, FORM, fieldsForForm } from '@lblod/submission-form-helpers';
 import ListingTableRow from './table/row';
 import Field from '@lblod/ember-submission-form-fields/models/field';
+import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
 
 export default class ListingTableComponent extends Component {
   ListingTableRow = ListingTableRow;
+  isLast = isLast;
 
   constructor() {
     super(...arguments);

--- a/addon/components/listing/table/row.hbs
+++ b/addon/components/listing/table/row.hbs
@@ -1,4 +1,14 @@
 <tr ...attributes>
+  {{#if (or @canMoveUp @canMoveDown)}}
+    <td>
+      <this.OrderButtonGroup
+        @canMoveUp={{@canMoveUp}}
+        @canMoveDown={{@canMoveDown}}
+        @moveUp={{@moveUp}}
+        @moveDown={{@moveDown}}
+      />
+    </td>
+  {{/if}}
   {{#if @showIndex}}
     <td>
       {{this.index}}

--- a/addon/components/listing/table/row.js
+++ b/addon/components/listing/table/row.js
@@ -3,8 +3,11 @@ import {
   getChildrenForPropertyGroup,
   getTopLevelPropertyGroups,
 } from '@lblod/ember-submission-form-fields/utils/model-factory';
+import OrderButtonGroup from '@lblod/ember-submission-form-fields/components/listing/order-button-group';
 
 export default class ListingTableRow extends Component {
+  OrderButtonGroup = OrderButtonGroup;
+
   constructor() {
     super(...arguments);
 

--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -1,8 +1,17 @@
 {{#if @useNewListingLayout}}
   <div class="sf-listing-sub-form au-o-box">
-    {{#if (or @subForm.itemLabel @canRemove)}}
+    {{#if (or @subForm.itemLabel @canMoveUp @canMoveDown @canRemove)}}
       <AuToolbar @size={{this.size}} as |Group|>
         <Group>
+          {{#if (or @canMoveUp @canMoveDown)}}
+            <this.OrderButtonGroup
+              @canMoveUp={{@canMoveUp}}
+              @canMoveDown={{@canMoveDown}}
+              @moveUp={{@moveUp}}
+              @moveDown={{@moveDown}}
+              class="au-u-flex-self-start"
+            />
+          {{/if}}
           {{#if @subForm.itemLabel}}
             <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
               {{@subForm.itemLabel}}
@@ -45,7 +54,19 @@
   </div>
 {{else}}
   {{#if @subForm.itemLabel}}
-    <div class="au-u-margin-bottom-small">
+    <div
+      class="au-u-margin-bottom-small
+        {{if (or @canMoveUp @canMoveDown) 'au-u-flex'}}"
+    >
+      {{#if (or @canMoveUp @canMoveDown)}}
+        <this.OrderButtonGroup
+          @canMoveUp={{@canMoveUp}}
+          @canMoveDown={{@canMoveDown}}
+          @moveUp={{@moveUp}}
+          @moveDown={{@moveDown}}
+          class="au-u-flex-self-start au-u-margin-right-small"
+        />
+      {{/if}}
       <AuHeading @level={{this.titleLevel}} @skin={{this.titleSkin}}>
         {{@subForm.itemLabel}}
       </AuHeading>

--- a/addon/components/sub-form.js
+++ b/addon/components/sub-form.js
@@ -1,10 +1,12 @@
 import Component from '@glimmer/component';
 import { getTopLevelPropertyGroups } from '../utils/model-factory';
 import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
+import OrderButtonGroup from '@lblod/ember-submission-form-fields/components/listing/order-button-group';
 
 export default class SubFormComponent extends Component {
   propertyGroups = []; // NOTE don't think this needs to be an ember array as it will never change
   isLast = isLast;
+  OrderButtonGroup = OrderButtonGroup;
 
   constructor() {
     super(...arguments);

--- a/addon/models/listing.js
+++ b/addon/models/listing.js
@@ -12,12 +12,16 @@ export default class ListingModel {
     const { store, formGraph } = options;
 
     this.uri = uri;
+    this.store = store;
+    this.formGraph = formGraph;
+
     this.rdflibLabel = store.any(uri, SHACL('name'), undefined, formGraph);
     this.rdflibOrder = store.any(uri, SHACL('order'), undefined, formGraph);
     this.rdflibPath = store.any(uri, SHACL('path'), undefined, formGraph);
     this.rdflibScope = store.any(uri, FORM('scope'), undefined, formGraph);
     this.rdflibOptions = store.any(uri, FORM('options'), undefined, formGraph);
     this.rdflibCanAdd = store.any(uri, FORM('canAdd'), undefined, formGraph);
+
     let rdflibMinCount = store.any(
       uri,
       SHACL('minCount'),
@@ -86,6 +90,17 @@ export default class ListingModel {
   rdflibCanRemove = null;
   get canRemove() {
     return this.rdflibCanRemove && this.rdflibCanRemove.value == 1;
+  }
+
+  get canChangeOrder() {
+    let literal = this.store.any(
+      this.uri,
+      FORM('canChangeOrder'),
+      undefined,
+      this.formGraph
+    );
+
+    return literal ? Literal.toJS(literal) : false;
   }
 
   @tracked

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -16,6 +16,22 @@
   border-radius: var(--au-radius);
 }
 
+/* Listing order button styles */
+
+/* .sf-listing-order-button-group {} */
+
+/* !important is needed because we override Appuniversum styles and our custom css is loaded before it (which we can't change) */
+.sf-listing-order-button-group__button {
+  height: 1.8rem !important;
+  border: 0.1rem solid transparent !important;
+  padding: 0 !important;
+}
+
+.sf-listing-order-button-group__button:hover:not([disabled]) {
+  background-color: var(--au-gray-200) !important;
+  border: 0.1rem solid var(--au-gray-200) !important;
+}
+
 /* Can be removed once Appuniversum adds this by default, or removes the flex from the default version:
    https://github.com/appuniversum/ember-appuniversum/blob/8793c19fbd69e9a1cec2ed5c670efef4bd77b21d/app/styles/ember-appuniversum/_c-fieldset.scss#L49-L52C23
 */

--- a/tests/dummy/public/test-forms/sub-forms-focus-crud/form.ttl
+++ b/tests/dummy/public/test-forms/sub-forms-focus-crud/form.ttl
@@ -39,6 +39,7 @@ ext:chaptersL a form:Listing;
   form:createGenerator ext:chapterGenerator;
   form:canRemove true;
   form:canAdd true;
+  form:canChangeOrder true;
   form:addLabel "Add chapter";
   sh:group ext:mainPg;
   sh:order 2 .

--- a/tests/dummy/public/test-forms/tables/form.ttl
+++ b/tests/dummy/public/test-forms/tables/form.ttl
@@ -37,6 +37,7 @@ ext:administrativeUnitsL a form:Listing;
   form:canAdd true;
   form:addLabel "Voeg nieuw betrokken lokaal bestuur toe";
   form:canRemove true;
+  form:canChangeOrder true;
   sh:minCount 3;
   sh:maxCount 10;
   form:removeLabel "Verwijder";


### PR DESCRIPTION
This adds a new `form:canChangeOrder` predicate that adds new buttons which can be used to move listing items up or down. To enable the feature simply set the predicate to `true`.

```ttl
ext:someListing a form:Listing ;
  # a form:ListingTable ; # Optional, if you want the table display mode
  # ... other listing predicates
  form:canChangeOrder true .
```

<details>
<summary>Listing version</summary>

![image](https://github.com/lblod/ember-submission-form-fields/assets/3533236/b45f56c2-9678-4a33-8164-591b9e58bc5e)

</details>

<details>
<summary>(old) Listing version</summary>

![image](https://github.com/lblod/ember-submission-form-fields/assets/3533236/1a76f073-eb9c-404a-9f39-29642dc33150)
</details>

<details>
<summary>Table version</summary>

![image](https://github.com/lblod/ember-submission-form-fields/assets/3533236/fa68fbe0-37d1-4f29-9dd6-5c3f5e133a4b)
</details>
