### PR TITLE
Fix an issue where new listing order values aren't the highest value

### DIFF
--- a/addon/components/listing.js
+++ b/addon/components/listing.js
@@ -74,7 +74,7 @@ export default class ListingComponent extends Component {
     let highestOrderValue = 0;
 
     if (this.subForms.length) {
-      let lastSubForm = this.subForms[this.subForms.length - 1];
+      let lastSubForm = this.orderedSubForms.at(-1);
 
       highestOrderValue =
         getOrder(


### PR DESCRIPTION
We now use the highest order value to determine the next one instead of using the value from last subform in the list (which doesn't always have the highest order).

We forgot to adjust this logic when we fixed the other ordering bug in #149. After that change the `subforms` array was no longer sorted.