### PR TITLE
SFB-83: Fields can be positioned in a layout (try-out)

### DIFF
--- a/addon/components/rdf-form.js
+++ b/addon/components/rdf-form.js
@@ -15,12 +15,15 @@ export default class RdfForm extends Component {
 
   constructor() {
     super(...arguments);
+    console.log(`construct RDF form`);
 
     this.runGenerator({
       store: this.args.formStore,
       graphs: this.args.graphs,
       sourceNode: this.args.sourceNode,
     });
+
+    console.log(`generator ran`);
 
     this.propertyGroups = getTopLevelPropertyGroups({
       store: this.args.formStore,

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -57,6 +57,11 @@
                   Tables
                 </AuNavigationLink>
               </li>
+              <li class="au-c-list-navigation__item">
+                <AuNavigationLink @route="form" @model="layouts">
+                  Layouts
+                </AuNavigationLink>
+              </li>
             </ul>
           </nav>
         </div>

--- a/tests/dummy/public/test-forms/layouts/data.ttl
+++ b/tests/dummy/public/test-forms/layouts/data.ttl
@@ -1,0 +1,2 @@
+# Input
+<http://ember-submission-form-fields/source-node> <http://mu.semte.ch/vocabularies/ext/inputValue> "Simple value".

--- a/tests/dummy/public/test-forms/layouts/form.ttl
+++ b/tests/dummy/public/test-forms/layouts/form.ttl
@@ -10,8 +10,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
 
-
-
 ##########################################################
 # form
 ##########################################################
@@ -28,8 +26,29 @@ ext:columnSectionPG a form:PropertyGroup;
     sh:name "Column section" ;
     sh:order 2 .
 
-ext:columnSectionPG form:hasField ext:inputFieldColumnLeft ;
-                    form:hasField ext:inputFieldColumnRight .
+ext:columnSectionPG form:hasField ext:columnLayout .
+
+##########################################################
+# Layout column
+##########################################################
+ext:columnLayout a form:Layout;
+  sh:group ext:columnSectionPG ;
+  schema:size 2;
+  ext:columns """
+  [
+    {
+      item: "ext:inputFieldColumnLeft",
+      column: 1,
+    },
+    {
+      item: "ext:inputFieldColumnRight",
+      column: 2,
+    }
+  ]
+  """ ;
+
+ext:columnLayout form:hasField ext:inputFieldColumnLeft ;
+                 form:hasField ext:inputFieldColumnRight .
 
 ##########################################################
 # Input column left

--- a/tests/dummy/public/test-forms/layouts/form.ttl
+++ b/tests/dummy/public/test-forms/layouts/form.ttl
@@ -1,0 +1,43 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/>.
+@prefix schema: <http://schema.org/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+
+
+
+##########################################################
+# form
+##########################################################
+ext:mainFg a form:FieldGroup.
+
+ext:form a form:Form;
+    form:hasFieldGroup ext:mainFg.
+
+##########################################################
+#  property-group
+##########################################################
+ext:mainPg a form:PropertyGroup;
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:name "Overview of all basic form fields" ;
+    sh:order 1 .
+
+##########################################################
+# Input
+##########################################################
+ext:inputField a form:Field ;
+    sh:name "Simple input" ;
+    sh:order 220 ;
+    sh:path ext:inputValue ;
+    form:options """{}""" ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:mainPg .
+
+ext:mainFg form:hasField ext:inputField .

--- a/tests/dummy/public/test-forms/layouts/form.ttl
+++ b/tests/dummy/public/test-forms/layouts/form.ttl
@@ -6,7 +6,6 @@
 @prefix displayTypes: <http://lblod.data.gift/display-types/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
 @prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
-@prefix lblodBesluit: <http://lblod.data.gift/vocabularies/besluit/>.
 @prefix schema: <http://schema.org/>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
@@ -19,25 +18,38 @@
 ext:mainFg a form:FieldGroup.
 
 ext:form a form:Form;
-    form:hasFieldGroup ext:mainFg.
+    form:hasFieldGroup ext:columnSectionPG.
 
 ##########################################################
-#  property-group
+# Section that holds a column layout
 ##########################################################
-ext:mainPg a form:PropertyGroup;
-    sh:description "parent property-group, used to group fields and property-groups together";
-    sh:name "Overview of all basic form fields" ;
-    sh:order 1 .
+ext:columnSectionPG a form:PropertyGroup;
+    sh:description "Property group that will have two input fields as columns";
+    sh:name "Column section" ;
+    sh:order 2 .
+
+ext:columnSectionPG form:hasField ext:inputFieldColumnLeft ;
+                    form:hasField ext:inputFieldColumnRight .
 
 ##########################################################
-# Input
+# Input column left
 ##########################################################
-ext:inputField a form:Field ;
-    sh:name "Simple input" ;
-    sh:order 220 ;
+ext:inputFieldColumnLeft a form:Field ;
+    sh:name "Simple left" ;
+    sh:order 3 ;
     sh:path ext:inputValue ;
     form:options """{}""" ;
     form:displayType displayTypes:defaultInput ;
-    sh:group ext:mainPg .
+    sh:group ext:columnSectionPG .
 
-ext:mainFg form:hasField ext:inputField .
+##########################################################
+# Input column right
+##########################################################
+ext:inputFieldColumnRight a form:Field ;
+    sh:name "Simple right" ;
+    sh:order 4 ;
+    sh:path ext:inputValue ;
+    form:options """{}""" ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group ext:columnSectionPG .
+


### PR DESCRIPTION
## ID
 [SFB-83](https://binnenland.atlassian.net/browse/SFB-83)

 ## Description

 When adding fields/sections/.. to a form now it is always added below the previous item. This is because RDF form does not know how to add columns for example. Find a way on how we can add a column layout, etc... to the form. Definitely check the issue above there are some attachments that can give you a start.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

**NOT testable yet**
 Try creating a form with two fields in columns

 ## Links to other PR's

 - /