### PR TITLE
SFB-71: Update concept-scheme-selector

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -31,11 +31,9 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = this.getFieldOptionsAsObject(this.args.field.options);
+    const fieldOptions = this.args.field.options;
 
-    if (!this.isValidFieldOptions(fieldOptions)) {
-      console.error(`Options are invalid.`);
-
+    if (!this.hasValidFieldOptions(fieldOptions)) {
       return;
     }
 
@@ -97,38 +95,28 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     super.updateValidations();
   }
 
-  getFieldOptionsAsObject(fieldOptions) {
-    if (typeof fieldOptions == 'string') {
-      try {
-        return JSON.parse(fieldOptions.trim());
-      } catch (error) {
-        console.error(` | Could not parse string options to json object`);
-        console.error(` | `, error);
+  hasValidFieldOptions() {
+    if (!this.args.field.options) {
+      console.error(
+        `Options are invalid. For field Field "${this.args.field.label}" (${this.args.field.displayType})`
+      );
 
-        return {};
-      }
-    }
-
-    return fieldOptions;
-  }
-
-  isValidFieldOptions(fieldOptions) {
-    let config = this.getFieldOptionsAsObject(fieldOptions);
-
-    if (!config) {
       return false;
     }
 
     const requiredProperties = ['conceptScheme'];
     const missingProperties = [];
     for (const required of requiredProperties) {
-      if (!Object.keys(config).includes(required)) {
+      if (!Object.keys(this.args.field.options).includes(required)) {
         missingProperties.push(required);
       }
     }
 
     if (missingProperties.length !== 0) {
-      console.warn(`Object is missing keys: `, missingProperties.join(', '));
+      console.warn(
+        `Field "${this.args.field.label}" (${this.args.field.displayType}) is missing keys: `,
+        missingProperties.join(', ')
+      );
 
       return false;
     }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -33,7 +33,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
 
-    if (!this.hasValidFieldOptions(fieldOptions)) {
+    if (!this.hasValidFieldOptions()) {
       return;
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -26,7 +26,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     super(...arguments);
 
     this.loadOptions();
-    // this.loadProvidedValue();
+    this.loadProvidedValue();
   }
 
   loadOptions() {

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -24,13 +24,21 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
   constructor() {
     super(...arguments);
+
     this.loadOptions();
-    this.loadProvidedValue();
+    // this.loadProvidedValue();
   }
 
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
-    const fieldOptions = this.args.field.options;
+    const fieldOptions = this.getFieldOptionsAsObject(this.args.field.options);
+
+    if (!this.isValidFieldOptions(fieldOptions)) {
+      console.error(`Options are invalid.`);
+
+      return;
+    }
+
     const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     /**
@@ -87,5 +95,44 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
     this.hasBeenFocused = true;
     super.updateValidations();
+  }
+
+  getFieldOptionsAsObject(fieldOptions) {
+    if (typeof fieldOptions == 'string') {
+      try {
+        return JSON.parse(fieldOptions.trim());
+      } catch (error) {
+        console.error(` | Could not parse string options to json object`);
+        console.error(` | `, error);
+
+        return {};
+      }
+    }
+
+    return fieldOptions;
+  }
+
+  isValidFieldOptions(fieldOptions) {
+    let config = this.getFieldOptionsAsObject(fieldOptions);
+
+    if (!config) {
+      return false;
+    }
+
+    const requiredProperties = ['conceptScheme'];
+    const missingProperties = [];
+    for (const required of requiredProperties) {
+      if (!Object.keys(config).includes(required)) {
+        missingProperties.push(required);
+      }
+    }
+
+    if (missingProperties.length !== 0) {
+      console.warn(`Object is missing keys: `, missingProperties.join(', '));
+
+      return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
## ID
[ SFB-71](https://binnenland.atlassian.net/browse/SFB-71)

 ## Description

In the `form-builder` when selecting the `dropdown` component it wants to render it in our "preview" form. As the `concept-scheme-selector` is not provided with options yet it breaks the form and the application is unusable. 

These changes check if there are (valid) options proved to use in the component else it is just rendering a dropdown without options. 

 ## Type of change

 - [x] Bug fix  => for `form-builder`
 - [x] New feature => validation
 - [ ] Breaking change
 - [ ] Other

 ## How to test

In the dummy app remove or change the options of the dropdown and try to make the form break because of it.

Talking about this option selector..
```
##########################################################
# Dropdown
##########################################################
ext:conceptSchemeSelectorField a form:Field ;
    sh:name "Select" ;
    sh:order 270 ;
    sh:path ext:conceptSchemeSelectorValue ;
    form:options """{"conceptScheme":"http://example-concept-schemes/concept-schemes/foo-bar-baz","searchEnabled":false}""" ;
    form:displayType displayTypes:conceptSchemeSelector ;
    sh:group ext:mainPg .

ext:mainFg form:hasField ext:conceptSchemeSelectorField .
```

 ## Links to other PR's

 -  [Comment](https://github.com/lblod/frontend-form-builder/pull/55#pullrequestreview-1736708050) in form builder PR