### PR TITLE
fix: order can be undefined

### DIFF
--- a/addon/components/listing.js
+++ b/addon/components/listing.js
@@ -437,5 +437,5 @@ function hasOrder(subject, store, graph) {
 function getOrder(subject, store, graph) {
   let order = store.any(subject, ORDER, undefined, graph);
 
-  return parseInt(order.value);
+  return parseInt(order?.value) || 1;
 }


### PR DESCRIPTION
when using getOrder, e.g. to decide the order of a new field being added, the order can be undefined if the existing field didn't have an order. This causes getOrder to raise an exception. This sets the order to 0 if no order is defined.