### PR TITLE
SFB-71: Show a warning when the field with options is missing option predicate

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -8,6 +8,7 @@ import {
   triplesForPath,
 } from '@lblod/submission-form-helpers';
 import { namedNode } from 'rdflib';
+import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 
 export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent extends InputFieldComponent {
   @tracked options = [];
@@ -50,6 +51,11 @@ export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent e
     const { sourceGraph, metaGraph } = this.args.graphs;
     const path = this.args.field.rdflibPath;
     const options = this.args.field.options;
+
+    if (!hasValidFieldOptions(this.args.field, ['conceptScheme', 'orderBy'])) {
+      return;
+    }
+
     const scheme = new namedNode(options.conceptScheme);
 
     let orderBy;

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -52,7 +52,7 @@ export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent e
     const path = this.args.field.rdflibPath;
     const options = this.args.field.options;
 
-    if (!hasValidFieldOptions(this.args.field, ['conceptScheme', 'orderBy'])) {
+    if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
       return;
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -38,7 +38,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
 
-    if (!hasValidFieldOptions(this.args.field)) {
+    if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
       return;
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -9,6 +9,7 @@ import {
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { namedNode } from 'rdflib';
+import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -36,6 +37,11 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
+
+    if (!hasValidFieldOptions(this.args.field)) {
+      return;
+    }
+
     const conceptScheme = new namedNode(fieldOptions.conceptScheme);
 
     /**

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { SKOS } from '@lblod/submission-form-helpers';
 import { namedNode } from 'rdflib';
+import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 
 export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends SimpleInputFieldComponent {
   @tracked options = [];
@@ -15,6 +16,11 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
+
+    if (!hasValidFieldOptions(this.args.field)) {
+      return;
+    }
+
     const conceptScheme = new namedNode(fieldOptions.conceptScheme);
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -17,7 +17,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
 
-    if (!hasValidFieldOptions(this.args.field)) {
+    if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
       return;
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -8,6 +8,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { namedNode } from 'rdflib';
+import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -33,7 +34,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
 
-    if (!this.hasValidFieldOptions()) {
+    if (!hasValidFieldOptions(this.args.field)) {
       return;
     }
 
@@ -93,34 +94,5 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
     this.hasBeenFocused = true;
     super.updateValidations();
-  }
-
-  hasValidFieldOptions() {
-    if (!this.args.field.options) {
-      console.error(
-        `Options are invalid. For field Field "${this.args.field.label}" (${this.args.field.displayType})`
-      );
-
-      return false;
-    }
-
-    const requiredProperties = ['conceptScheme'];
-    const missingProperties = [];
-    for (const required of requiredProperties) {
-      if (!Object.keys(this.args.field.options).includes(required)) {
-        missingProperties.push(required);
-      }
-    }
-
-    if (missingProperties.length !== 0) {
-      console.warn(
-        `Field "${this.args.field.label}" (${this.args.field.displayType}) is missing keys: `,
-        missingProperties.join(', ')
-      );
-
-      return false;
-    }
-
-    return true;
   }
 }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -34,7 +34,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
 
-    if (!hasValidFieldOptions(this.args.field)) {
+    if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
       return;
     }
 

--- a/addon/utils/has-valid-field-options.js
+++ b/addon/utils/has-valid-field-options.js
@@ -1,0 +1,30 @@
+export function hasValidFieldOptions(
+  fieldModel,
+  requiredProperties = ['conceptScheme']
+) {
+  if (!fieldModel.options) {
+    console.error(
+      `Options are invalid. For field Field "${fieldModel.label}" (${fieldModel.displayType})`
+    );
+
+    return false;
+  }
+
+  const missingProperties = [];
+  for (const required of requiredProperties) {
+    if (!Object.keys(fieldModel.options).includes(required)) {
+      missingProperties.push(required);
+    }
+  }
+
+  if (missingProperties.length !== 0) {
+    console.warn(
+      `Field "${fieldModel.label}" (${fieldModel.displayType}) is missing keys: `,
+      missingProperties.join(', ')
+    );
+
+    return false;
+  }
+
+  return true;
+}

--- a/addon/utils/has-valid-field-options.js
+++ b/addon/utils/has-valid-field-options.js
@@ -1,7 +1,4 @@
-export function hasValidFieldOptions(
-  fieldModel,
-  requiredProperties = ['conceptScheme']
-) {
+export function hasValidFieldOptions(fieldModel, requiredProperties = []) {
   if (!fieldModel.options) {
     console.error(
       `Options are invalid. For field Field "${fieldModel.label}" (${fieldModel.displayType})`


### PR DESCRIPTION
## ID
 [SFB-71](https://binnenland.atlassian.net/browse/SFB-71)

 ## Description

 When not passing any options to the fields that require them the form breaks. This means that if one component does not have the correct options passed to it breaks the whole form.

 ## Type of change

 - [x] Bug fix
 - [x] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

Remove the `form:options` in the `.ttl` files for each field that has it as a predicate. this will show warnings on what is missing and not break the complete RDF-form.

 ## Links to other PR's

 - Same as https://github.com/lblod/ember-submission-form-fields/pull/156