### PR TITLE
Make sure the remote url preview link is displayed when available

### DIFF
--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -23,6 +23,7 @@ const RPIO_HTTP = new Namespace(
 
 class RemoteUrl {
   @tracked errors = [];
+  @tracked address;
 
   constructor({ uri, address, errors }) {
     this.uri = uri;


### PR DESCRIPTION
We accidentally introduced a regression when resolving Appuniversum deprecations. The 2-way-binding that was previously used also notified the rendering system so the link was displayed. When we switched to regular events for content updates we forgot to mark the address property as tracked and as a result the template wouldn't rerender anymore.