### PR TITLE
Hide labels in "show" mode

### DIFF
--- a/addon/components/rdf-input-fields/input-field.js
+++ b/addon/components/rdf-input-fields/input-field.js
@@ -55,10 +55,13 @@ export default class InputFieldComponent extends Component {
   }
 
   get isRequired() {
-    return this.constraints.some(
-      (constraint) =>
-        constraint.type.value ===
-        'http://lblod.data.gift/vocabularies/forms/RequiredConstraint'
+    return (
+      !this.args.show &&
+      this.constraints.some(
+        (constraint) =>
+          constraint.type.value ===
+          'http://lblod.data.gift/vocabularies/forms/RequiredConstraint'
+      )
     );
   }
 

--- a/addon/components/rdf-input-fields/input.hbs
+++ b/addon/components/rdf-input-fields/input.hbs
@@ -6,12 +6,14 @@
     for={{this.inputId}}
   >
     {{@field.label}}
-    {{#if this.maxLength}}
-      <AuPill @skin={{unless this.hasRemainingCharacters "error"}}>
-        Resterende karakters:
-        {{this.remainingCharacters}}
-      </AuPill>
-    {{/if}}
+    {{#unless @show}}
+      {{#if this.maxLength}}
+        <AuPill @skin={{unless this.hasRemainingCharacters "error"}}>
+          Resterende karakters:
+          {{this.remainingCharacters}}
+        </AuPill>
+      {{/if}}
+    {{/unless}}
   </AuLabel>
 {{/unless}}
 


### PR DESCRIPTION
This hides all the "required" and "remaining character" labels when the form is in the read-only state. It fixes a regression that we introduced when we ["deduped" the fields](https://github.com/lblod/ember-submission-form-fields/pull/54).

**To test:**
- Flip the "read-only mode" toggle in the top bar
- verify that there are no "required" or "remaining character" labels (you can temporarily add extra constraints to some fields if you want)
