### PR TITLE
Link the "read-only" toggle to a query param

### DIFF
--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class ApplicationController extends Controller {
-  @service formConfig;
+  queryParams = ['readOnly'];
+  @tracked readOnly = false;
 }

--- a/tests/dummy/app/services/form-config.js
+++ b/tests/dummy/app/services/form-config.js
@@ -1,6 +1,9 @@
-import Service from '@ember/service';
-import { tracked } from '@glimmer/tracking';
+import Service, { service } from '@ember/service';
 
 export default class FormConfigService extends Service {
-  @tracked isReadOnly = false;
+  @service router;
+
+  get isReadOnly() {
+    return this.router.currentRoute.queryParams.readOnly === 'true';
+  }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -85,8 +85,8 @@
         <AuToolbar @border="bottom" @size="small" @skin="tint" as |Group|>
           <Group>
             <AuToggleSwitch
-              @checked={{this.formConfig.isReadOnly}}
-              @onChange={{fn (mut this.formConfig.isReadOnly)}}
+              @checked={{this.readOnly}}
+              @onChange={{fn (mut this.readOnly)}}
             >Read-only mode</AuToggleSwitch>
           </Group>
         </AuToolbar>


### PR DESCRIPTION
This ensures that the "read-only" toggle state is persisted after reloading the page in the test app.

Failing CI should be fixed by #180 