### PR TITLE
Fix some auto focus issues

### DIFF
--- a/addon/-private/modifiers/autofocus.js
+++ b/addon/-private/modifiers/autofocus.js
@@ -1,0 +1,5 @@
+import { modifier } from 'ember-modifier';
+
+export const autofocus = modifier((element) => {
+  element.focus();
+});

--- a/addon/components/rdf-input-fields/remote-urls/edit.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/edit.hbs
@@ -18,8 +18,10 @@
           value={{remoteUrl.address}}
           id="{{this.inputId}}-{{index}}"
           placeholder="http://www.uw-bestuur.be/specifiek-document"
-          {{auto-focus}}
           {{on "blur" (fn this.updateRemoteUrl remoteUrl)}}
+          {{(if
+            (eq remoteUrl this.remoteUrlToFocus) (modifier this.autofocus)
+          )}}
         />
         {{#if remoteUrl.isInvalid}}
           {{#each remoteUrl.errors as |error|}}

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -11,6 +11,7 @@ import { RDF, NIE } from '@lblod/submission-form-helpers';
 import { namedNode, NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { guidFor } from '@ember/object/internals';
+import { autofocus } from '../../../-private/modifiers/autofocus';
 
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
 const REQUEST_HEADER = new namedNode(
@@ -42,6 +43,7 @@ class RemoteUrl {
 
 export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldComponent {
   inputId = `remote-urls-${guidFor(this)}`;
+  autofocus = autofocus;
 
   get inputFor() {
     if (this.remoteUrls.length) {
@@ -51,6 +53,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
   }
 
   @tracked remoteUrls = [];
+  @tracked remoteUrlToFocus = null;
 
   observerLabel = `remote-urls-${guidFor(this)}`; // Could have used uuidv4, but more consistent accross components
 
@@ -175,14 +178,14 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
 
   @action
   addUrlField() {
-    this.remoteUrls = [
-      ...this.remoteUrls,
-      new RemoteUrl({
-        uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuidv4()}`),
-        address: '',
-        errors: [],
-      }),
-    ];
+    const remoteUrl = new RemoteUrl({
+      uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuidv4()}`),
+      address: '',
+      errors: [],
+    });
+
+    this.remoteUrlToFocus = remoteUrl;
+    this.remoteUrls = [...this.remoteUrls, remoteUrl];
   }
 
   @action

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
@@ -44,8 +44,10 @@
                 @disabled={{@show}}
                 value={{field.value}}
                 aria-labelledby={{this.amountColumnId}}
-                {{auto-focus}}
                 {{on "blur" (fn this.updatePrice field)}}
+                {{(if
+                  (eq field this.taxEntryToFocus) (modifier this.autofocus)
+                )}}
               />
               {{#each field.errors as |error|}}
                 <AuHelpText @error={{true}}>

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.js
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.js
@@ -5,6 +5,7 @@ import InputFieldComponent from '@lblod/ember-submission-form-fields/components/
 import { RDF, triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
+import { autofocus } from '../../-private/modifiers/autofocus';
 
 const uriTemplate = 'http://data.lblod.info/tax-rates';
 const lblodBesluit = `http://lblod.data.gift/vocabularies/besluit`;
@@ -38,9 +39,11 @@ class TaxEntry {
 
 export default class RdfInputFieldsVlabelOpcentiemComponent extends InputFieldComponent {
   amountColumnId = 'amount-column-' + guidFor(this);
+  autofocus = autofocus;
 
   @tracked taxRateSubject = null;
   @tracked taxEntries = [];
+  @tracked taxEntryToFocus = null;
   @tracked differentiatie = false;
 
   constructor() {
@@ -193,10 +196,9 @@ export default class RdfInputFieldsVlabelOpcentiemComponent extends InputFieldCo
 
   @action
   addPrice() {
-    this.taxEntries = [
-      ...this.taxEntries,
-      new TaxEntry({ value: '', errors: [] }),
-    ];
+    const taxEntry = new TaxEntry({ value: '', errors: [] });
+    this.taxEntryToFocus = taxEntry;
+    this.taxEntries = [...this.taxEntries, taxEntry];
   }
 
   @action

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.2.0",
         "ember-concurrency": "^2.3.2 || ^3.0.0",
+        "ember-modifier": "^4.1.0",
         "ember-truth-helpers": "^3.0.0",
         "forking-store": "^2.0.0",
         "rdflib": "^2.2.19",
@@ -3112,7 +3113,6 @@
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.6.tgz",
       "integrity": "sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==",
-      "dev": true,
       "dependencies": {
         "@embroider/shared-internals": "^2.2.3",
         "broccoli-funnel": "^3.0.8",
@@ -14491,7 +14491,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
       "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
-      "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-concurrency": "^2.3.2 || ^3.0.0",
+    "ember-modifier": "^4.1.0",
     "ember-truth-helpers": "^3.0.0",
     "forking-store": "^2.0.0",
     "rdflib": "^2.2.19",


### PR DESCRIPTION
Appuniversum v3.1 [removed their internal use](https://github.com/appuniversum/ember-appuniversum/blob/master/CHANGELOG.md#house-internal) of the `@zestia/ember-auto-focus` addon. It seems we were implicitly depending on this addon as well. Instead of adding the addon to our own dependency list, I opted for a custom solution, since that means we have less dependencies to maintain, and it's a very simple implementation for our use-case.

This also fixes the issue where the input fields would be focused when the forms are rendered for the first time. Now it only focuses a field when the user adds a new entry.