### PR TITLE
SFB-206: POC show fields without link to group

### DIFF
--- a/addon/components/rdf-form.hbs
+++ b/addon/components/rdf-form.hbs
@@ -20,6 +20,30 @@
           {{!Temporary argument so we don't break the css hacks in the LPDC module}}
         />
       {{/if}}
+      {{#if (this.isFieldModel model)}}
+        <div class="au-u-margin-left">
+          {{#let
+            (component-for-display-type model.displayType show=@show)
+            as |FormField|
+          }}
+            <FormField
+              @field={{model}}
+              @form={{@form}}
+              @formStore={{@formStore}}
+              @graphs={{@graphs}}
+              @sourceNode={{@sourceNode}}
+              @forceShowErrors={{@forceShowErrors}}
+              @cacheConditionals={{@cacheConditionals}}
+              @show={{@show}}
+            />
+          {{/let}}
+
+          {{#if model.help}}
+            {{! template-lint-disable no-triple-curlies}}
+            <AuHelpText>{{{model.help}}}</AuHelpText>
+          {{/if}}
+        </div>
+      {{/if}}
     {{/each}}
   {{/if}}
 </div>

--- a/addon/components/rdf-form.hbs
+++ b/addon/components/rdf-form.hbs
@@ -1,19 +1,25 @@
 <div class="au-o-grid au-o-grid--small" ...attributes>
-  {{#each this.sections as |section|}}
-    <FormSection
-      class={{@groupClass}}
-      @form={{@form}}
-      @section={{section}}
-      @formStore={{@formStore}}
-      @graphs={{@graphs}}
-      @sourceNode={{@sourceNode}}
-      @forceShowErrors={{@forceShowErrors}}
-      @cacheConditionals={{@cacheConditionals}}
-      @last={{this.isLast this.sections section}}
-      @show={{@show}}
-      @level={{@level}}
-      @useNewListingLayout={{@useNewListingLayout}}
-      {{!Temporary argument so we don't break the css hacks in the LPDC module}}
-    />
-  {{/each}}
+  {{#if this.setupRdfForm.isRunning}}
+    <AuLoader />
+  {{else}}
+    {{#each this.topLevelModels as |model|}}
+      {{#if (this.isSectionModel model)}}
+        <FormSection
+          class={{@groupClass}}
+          @form={{@form}}
+          @section={{model}}
+          @formStore={{@formStore}}
+          @graphs={{@graphs}}
+          @sourceNode={{@sourceNode}}
+          @forceShowErrors={{@forceShowErrors}}
+          @cacheConditionals={{@cacheConditionals}}
+          @last={{this.isLast this.sections model}}
+          @show={{@show}}
+          @level={{@level}}
+          @useNewListingLayout={{@useNewListingLayout}}
+          {{!Temporary argument so we don't break the css hacks in the LPDC module}}
+        />
+      {{/if}}
+    {{/each}}
+  {{/if}}
 </div>

--- a/addon/components/rdf-form.hbs
+++ b/addon/components/rdf-form.hbs
@@ -21,7 +21,9 @@
         />
       {{/if}}
       {{#if (this.isFieldModel model)}}
-        <div class="au-u-margin-left">
+        <div
+          class="au-o-flow au-u-margin-left au-u-margin-right au-u-margin-top"
+        >
           {{#let
             (component-for-display-type model.displayType show=@show)
             as |FormField|

--- a/addon/components/rdf-form.js
+++ b/addon/components/rdf-form.js
@@ -12,6 +12,7 @@ import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last
 import { A } from '@ember/array';
 import { restartableTask } from 'ember-concurrency';
 import Section from '@lblod/ember-submission-form-fields/models/section';
+import Field from '@lblod/ember-submission-form-fields/models/field';
 import { action } from '@ember/object';
 
 export default class RdfForm extends Component {
@@ -95,11 +96,16 @@ export default class RdfForm extends Component {
   }
 
   get topLevelModels() {
-    return this.topLevelElements;
+    return this.topLevelElements.sort((a, b) => a.order - b.order);
   }
 
   @action
   isSectionModel(model) {
     return model instanceof Section;
+  }
+
+  @action
+  isFieldModel(model) {
+    return model instanceof Field;
   }
 }

--- a/addon/components/rdf-form.js
+++ b/addon/components/rdf-form.js
@@ -16,7 +16,6 @@ import Field from '@lblod/ember-submission-form-fields/models/field';
 import { action } from '@ember/object';
 
 export default class RdfForm extends Component {
-  sections = []; // NOTE don't think this needs to be an ember array as it will never change
   isLast = isLast;
   topLevelElements = A([]);
 
@@ -34,12 +33,12 @@ export default class RdfForm extends Component {
       sourceNode: this.args.sourceNode,
     });
 
-    this.sections = getTopLevelSections({
+    const sections = getTopLevelSections({
       store: this.args.formStore,
       graphs: this.args.graphs,
       form: this.args.form,
     });
-    this.topLevelElements.pushObjects(this.sections);
+    this.topLevelElements.pushObjects(sections);
 
     const fields = getTopLevelFields({
       store: this.args.formStore,
@@ -97,6 +96,10 @@ export default class RdfForm extends Component {
 
   get topLevelModels() {
     return this.topLevelElements.sort((a, b) => a.order - b.order);
+  }
+
+  get sections() {
+    return this.topLevelElements.filter((model) => this.isSectionModel(model));
   }
 
   @action

--- a/addon/utils/model-factory.js
+++ b/addon/utils/model-factory.js
@@ -213,36 +213,35 @@ export function getChildrenForSection(section, { form, store, graphs, node }) {
 export function getTopLevelFields({ store, graphs }) {
   const rootNode = getRootNodeForm({ store, graphs });
 
-  const includedIn = store
+  const includedSubjects = store
     .match(rootNode, FORM('includes'), undefined, graphs.formGraph)
     .map((triple) => triple.object);
 
-  const unlinkedSubjects = includedIn.map((includedItem) => {
+  const unlinkedFieldSubjects = [];
+  for (const subject of includedSubjects) {
     const isOfTypeField = store.any(
-      includedItem,
+      subject,
       RDF('type'),
       FORM('Field'),
       graphs.formGraph
     );
 
     if (!isOfTypeField) {
-      return;
+      continue;
     }
 
-    // sectionContainingItem => rename to subjectContainingItem?
-    const linkedTo = sectionContainingItem(includedItem, {
+    //sectionContainingItem => rename to subjectContainingItem?
+    const linkedTo = sectionContainingItem(subject, {
       store: store,
       formGraph: graphs.formGraph,
     });
 
     if (!linkedTo) {
-      return includedItem;
+      unlinkedFieldSubjects.push(subject);
     }
-  });
+  }
 
-  const unlinkedFields = unlinkedSubjects.filter((item) => item);
-
-  return unlinkedFields
+  return unlinkedFieldSubjects
     .map(
       (subject) => new Field(subject, { store, formGraph: graphs.formGraph })
     )


### PR DESCRIPTION
## ID
 [SFB-206](https://binnenland.atlassian.net/browse/SFB-206)

 ## Description

We want to show fields with links in the form. When adding a field in the builder you must assign the link to property for that field to be able to show the field in the preview. 

This change makes it that the "toplevel" fields will be shown even when they are not linked to a section/propertygroup

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

1. Go to the builder and add a field
2. Do not assign the link to property in the builder
3. The field should show in the form preview

 ## Links to other PR's

 - /

 ## Attachments

**v1** 

![image](https://github.com/lblod/ember-submission-form-fields/assets/36266973/1217f020-94b5-412c-baa8-23c85f68da2b)
