### PR TITLE
Handle "not ok" responses while preparing the bulk zip files

### DIFF
--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -36,6 +36,7 @@ class FileField {
 
 export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
   @service store;
+  @service toaster;
   @tracked files = A();
   inputId = `files-${guidFor(this)}`; // TODO for now this doesn't work on the <AuFileUpload /> component.
 
@@ -180,7 +181,15 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
 
   downloadAsZip = dropTask(async () => {
     const promises = this.files.map((file) => {
-      return fetch(file.record.downloadLink);
+      return fetch(file.record.downloadLink).then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Something went wrong while trying to download '${file.record.downloadLink}': ${response.status} ${response.statusText}`
+          );
+        }
+
+        return response;
+      });
     });
 
     try {

--- a/addon/components/rdf-input-fields/remote-urls/show.js
+++ b/addon/components/rdf-input-fields/remote-urls/show.js
@@ -92,7 +92,15 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
 
   downloadAsZip = task(async () => {
     const promises = this.downloadableRemoteUrls.map((remoteUrl) => {
-      return fetch(remoteUrl.downloadLink);
+      return fetch(remoteUrl.downloadLink).then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            `Something went wrong while trying to download '${remoteUrl.downloadLink}': ${response.status} ${response.statusText}`
+          );
+        }
+
+        return response;
+      });
     });
 
     try {

--- a/tests/dummy/app/mocks/handlers/files.js
+++ b/tests/dummy/app/mocks/handlers/files.js
@@ -40,10 +40,12 @@ export const filesHandlers = [
       file = Object.values(mockFiles).at(0);
     }
 
-    const buffer = await fetch(file.path).then((response) =>
-      response.arrayBuffer()
-    );
+    const response = await fetch(file.path);
+    if (!response.ok) {
+      return response;
+    }
 
+    const buffer = await response.arrayBuffer();
     return HttpResponse.arrayBuffer(buffer, {
       headers: {
         // This matches the response of the file-service


### PR DESCRIPTION
Small follow-up to #181 

We forgot to handle the cases where `fetch` doesnt't throw, but the server doesn't send an "ok" response either. The most probably case will be 404 errors. Now we display the error message if the file doesn't exist.

(This doesn't need to appear in the changelog since the previous PR hasn't been released yet)

**To test**
- run the test app
- rename the dummy files in `tests/dummy/public/mock-files` to something else
- try to download the zips by clicking the buttons in the test app
- it should display an error message (in a toast message and the console)