### PR TITLE
SFB-248: radio button concept scheme selector with order by property in form:options

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -64,6 +64,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
     );
 
     if (orderStatement) {
+      // This is also passing NaN if the value is a string
       return parseInt(orderStatement.value);
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -26,10 +26,10 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
     }
 
     const conceptScheme = new namedNode(fieldOptions.conceptScheme);
-    this.options = this.args.formStore
+    this.options = this.store
       .match(undefined, SKOS('inScheme'), conceptScheme, this.metaGraph)
       .map((t) => {
-        const label = this.args.formStore.any(
+        const label = this.store.any(
           t.subject,
           SKOS('prefLabel'),
           undefined,
@@ -56,7 +56,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
   }
 
   getOrderForOption(orderBy, tripleSubject) {
-    const orderStatement = this.args.formStore.any(
+    const orderStatement = this.store.any(
       tripleSubject,
       orderBy,
       undefined,
@@ -68,6 +68,10 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
 
   get metaGraph() {
     return this.args.graphs.metaGraph;
+  }
+
+  get store() {
+    return this.args.formStore;
   }
 }
 

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -64,8 +64,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
     );
 
     if (orderStatement) {
-      // This is also passing NaN if the value is a string
-      return parseInt(orderStatement.value);
+      return orderStatement.value;
     }
 
     return 0;
@@ -83,5 +82,5 @@ function byLabel(a, b) {
 }
 
 function byOrder(a, b) {
-  return a.order - b.order;
+  return a.order.localeCompare(b.order, undefined, { numeric: true });
 }

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -63,11 +63,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
       this.metaGraph
     );
 
-    if (orderStatement) {
-      return `${orderStatement.value ?? ''}`;
-    }
-
-    return 0;
+    return `${orderStatement?.value ?? ''}`;
   }
 
   get metaGraph() {

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -63,6 +63,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
       this.metaGraph
     );
 
+    // This MUST be a string so our byOrder sorting function returns the correct result
     return `${orderStatement?.value ?? ''}`;
   }
 

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -64,7 +64,7 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
     );
 
     if (orderStatement) {
-      return orderStatement.value;
+      return `${orderStatement.value ?? ''}`;
     }
 
     return 0;

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -120,6 +120,19 @@ ext:radioButtonsField a form:Field ;
 ext:mainFg form:hasField ext:radioButtonsField .
 
 ##########################################################
+# Radio buttons with orderby
+##########################################################
+ext:radioButtonsWithOrderByField a form:Field ;
+    sh:name "Radio buttons with orderBy" ;
+    sh:order 211 ;
+    sh:path ext:radioButtonsValue ;
+    form:options """{"conceptScheme":"http://example-concept-schemes/concept-schemes/foo-bar-baz","orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+    form:displayType displayTypes:conceptSchemeRadioButtons ;
+    sh:group ext:mainPg .
+
+ext:mainFg form:hasField ext:radioButtonsWithOrderByField .
+
+##########################################################
 # Input
 ##########################################################
 ext:inputField a form:Field ;

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -126,7 +126,7 @@ ext:radioButtonsWithOrderByField a form:Field ;
     sh:name "Radio buttons with orderBy" ;
     sh:order 211 ;
     sh:path ext:radioButtonsValue ;
-    form:options """{"conceptScheme":"http://example-concept-schemes/concept-schemes/foo-bar-baz","orderBy": "http://purl.org/linked-data/cube#order"}""" ;
+    form:options """{"conceptScheme":"http://example-concept-schemes/concept-schemes/foo-bar-baz", "orderBy": "http://purl.org/linked-data/cube#order"}""" ;
     form:displayType displayTypes:conceptSchemeRadioButtons ;
     sh:group ext:mainPg .
 


### PR DESCRIPTION
## Issue
 [SFB-248](https://binnenland.atlassian.net/browse/SFB-248)

## Description

When the `form:options` have `orderBy` property defined sort the concepts by that order instead of `byLabel` (the default). 

## Testing

Go to the basic fields tab and look at the radio buttons with orderBy those are sorted by the orderBy predicate.


## Note

What bothers me is that we assume that `orderBy` is a number. @Rahien  should we do it now like this so we can have a look at a order predicate for sorting these in the future?