### PR TITLE
SFB-224: Required validation on currency input (fix)

### DIFF
--- a/addon/components/rdf-input-fields/currency-input.hbs
+++ b/addon/components/rdf-input-fields/currency-input.hbs
@@ -27,6 +27,7 @@
         allowMinus=true
         unmaskAsNumber=true
         inputType="number"
+        placeholder=""
       )
     }}
   />

--- a/addon/components/rdf-input-fields/currency-input.js
+++ b/addon/components/rdf-input-fields/currency-input.js
@@ -1,6 +1,8 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import { XSD } from '@lblod/submission-form-helpers';
+import { literal } from 'rdflib';
 
 export default class RdfInputFieldsCurrencyInputComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
@@ -9,13 +11,30 @@ export default class RdfInputFieldsCurrencyInputComponent extends SimpleInputFie
 
   @action
   updateValue(e) {
+    let updatedValue = null;
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
 
     if (e.target && e.target.value) {
       this.value = e.target.inputmask.unmaskedvalue();
-    } else {
-      this.value = null;
+      updatedValue = literal(Number(this.value), this.datatype);
     }
-    super.updateValue(this.value);
+
+    super.updateValue(updatedValue);
+  }
+
+  // Took this over from numerical-input.js
+  // When value 0 is filled in this added as that value
+  // When just updating the value with Number(0) no value is written to the path
+  get datatype() {
+    const number = Number(this.value);
+    if (!Number.isNaN(number) && Number.isFinite(number)) {
+      let datatype = XSD('decimal');
+      if (Number.isInteger(number) && Number.isSafeInteger(number)) {
+        datatype = XSD('integer');
+      }
+      return datatype;
+    }
+    // NOTE: everything that is not a number is a string.
+    return XSD('string');
   }
 }

--- a/addon/components/rdf-input-fields/currency-input.js
+++ b/addon/components/rdf-input-fields/currency-input.js
@@ -23,8 +23,8 @@ export default class RdfInputFieldsCurrencyInputComponent extends SimpleInputFie
   }
 
   // Took this over from numerical-input.js
-  // When value 0 is filled in this added as that value
-  // When just updating the value with Number(0) no value is written to the path
+  // When value 0 is filled it will be recognized as a deciaml or intiger
+  // instead of an invalid value
   get datatype() {
     const number = Number(this.value);
     if (!Number.isNaN(number) && Number.isFinite(number)) {

--- a/addon/components/rdf-input-fields/currency-input.js
+++ b/addon/components/rdf-input-fields/currency-input.js
@@ -13,8 +13,9 @@ export default class RdfInputFieldsCurrencyInputComponent extends SimpleInputFie
 
     if (e.target && e.target.value) {
       this.value = e.target.inputmask.unmaskedvalue();
-
-      super.updateValue(this.value);
+    } else {
+      this.value = null;
     }
+    super.updateValue(this.value);
   }
 }

--- a/tests/dummy/public/test-forms/validations/form.ttl
+++ b/tests/dummy/public/test-forms/validations/form.ttl
@@ -10,6 +10,7 @@ ext:mainForm a form:Form, form:TopLevelForm ;
     form:includes ext:errorNumericalInput ;
     form:includes ext:errorTextArea ;
     form:includes ext:errorSelect ;
+    form:includes ext:errorCurrencyInput ;
 
     # Warning fields
     form:includes ext:warningInput ;
@@ -77,6 +78,19 @@ ext:errorSelect a form:Field ;
       form:customValue <http://example-concept-schemes/concepts/grault> ;
       sh:resultMessage "Wrong choice!" ;
       sh:path ext:errorSelectValue ;
+    ] ;
+    form:partOf ext:errorSection .
+
+ext:errorCurrencyInput a form:Field ;
+    sh:name "Currency input" ;
+    sh:order 50 ;
+    form:displayType displayTypes:currencyInput ;
+    sh:path ext:currencyInputValue ;
+    form:validatedBy [
+      a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "This field is required" ;
+      sh:path ext:errorInputValue ;
     ] ;
     form:partOf ext:errorSection .
 

--- a/tests/dummy/public/test-forms/validations/form.ttl
+++ b/tests/dummy/public/test-forms/validations/form.ttl
@@ -90,7 +90,7 @@ ext:errorCurrencyInput a form:Field ;
       a form:RequiredConstraint ;
       form:grouping form:Bag ;
       sh:resultMessage "This field is required" ;
-      sh:path ext:errorInputValue ;
+      sh:path ext:currencyInputValue ;
     ] ;
     form:partOf ext:errorSection .
 


### PR DESCRIPTION
## Issue
 [SFB-224](https://binnenland.atlassian.net/browse/SFB-224)

## Description

The required validation on the currency input was not triggered when the user cleared the form as the value 0 was still in the field.

Now the value is set to null so the validation is triggered. When a user filled in the value **0** the required validation was also triggered as the value of the triple was not updated to zero but to no value. I found out that this was working with the numerical input and that they fixed it by updating the value as a literal with the integer or decimal datatype. 

The field uses the `hasBeenFocused` & `validation` check from the `SimpleInputField` but the currency input will specifically update the value to NULL when nothing is filled in.

## Testing

The currencyInput is added to the validation section here 
![image](https://github.com/lblod/ember-submission-form-fields/assets/36266973/b1ec14b9-721f-4f48-aef9-e646943dd7e8)

 1. Validation should not be visible on initial load
 2. When focused and no value filled in the error should be triggered
 3. Its possible to fill in the value `0` and not trigger the validation
 4. When a correct value is filled in no error is triggered