### PR TITLE
add mu:uuid when creating remote-url

### DIFF
--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -21,12 +21,14 @@ const REQUEST_HEADER = new namedNode(
 const RPIO_HTTP = new Namespace(
   'http://redpencil.data.gift/vocabularies/http/'
 );
+const MU = new Namespace('http://mu.semte.ch/vocabularies/core/');
 
 class RemoteUrl {
   @tracked errors = [];
   @tracked address;
 
-  constructor({ uri, address, errors }) {
+  constructor({ uuid, uri, address, errors }) {
+    this.uuid = uuid;
     this.uri = uri;
     this.address = address;
     this.errors = errors;
@@ -148,7 +150,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     removeSimpleFormValue(new NamedNode(uri), this.storeOptions); // remove hasPart
   }
 
-  insertRemoteDataObject({ uri, address }) {
+  insertRemoteDataObject({ uuid, uri, address }) {
     const triples = [
       {
         subject: uri,
@@ -156,6 +158,12 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
         object: new NamedNode(
           'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject'
         ),
+        graph: this.storeOptions.sourceGraph,
+      },
+      {
+        subject: uri,
+        predicate: MU('uuid'),
+        object: uuid,
         graph: this.storeOptions.sourceGraph,
       },
       {
@@ -178,8 +186,10 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
 
   @action
   addUrlField() {
+    const uuid = uuidv4()
     const remoteUrl = new RemoteUrl({
-      uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuidv4()}`),
+      uuid,
+      uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuid}`),
       address: '',
       errors: [],
     });
@@ -193,7 +203,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     remoteUrl.address = event.target.value.trim();
     const address = remoteUrl.address;
     this.removeRemoteDataObject(remoteUrl.uri);
-    this.insertRemoteDataObject({ uri: remoteUrl.uri, address });
+    this.insertRemoteDataObject({ uuid: remoteUrl.uuid, uri: remoteUrl.uri, address });
     this.hasBeenFocused = true;
     const errors = this.validationErrorsForAddress(address).map(
       (e) => e.resultMessage


### PR DESCRIPTION
A resource in the context graph databases SHOULD ALWAYS have 2 things. A rdf:type and a mu:uuid. When one is missing, down the line, issues occur. This component does not work in subsidies unless it has a mu uuid. In toezicht it does work because some mystical service adds it in the backend after a delta gets triggered. 