### PR TITLE
LMB-326: Form options to separate predicates v2

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -58,7 +58,19 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     /**
      * NOTE: Most forms are now implemented to have a default "true" behavior
      */
-    if (fieldOptions.searchEnabled !== undefined) {
+    if (!hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
+      const isEnabled = this.args.formStore.any(
+        this.args.field.uri,
+        FORM_OPTION('searchEnabled'),
+        undefined,
+        this.args.graphs.formGraph
+      );
+      if (!isEnabled) {
+        return;
+      }
+
+      this.searchEnabled = isEnabled == '1' ? true : false;
+    } else {
       this.searchEnabled = fieldOptions.searchEnabled;
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -77,7 +77,6 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
       .map((t) => {
-        console.log({ t });
         const label = this.args.formStore.any(
           t.subject,
           SKOS('prefLabel'),

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -11,8 +11,8 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
 @prefix eurio: <http://data.europa.eu/s66#> .
-
-
+@prefix formOption: <http://mu.semte.ch/vocabularies/ext/form-option> .
+@prefix exampleConceptSchemes: <http://example-concept-schemes/concept-schemes/> .
 
 ##########################################################
 # form
@@ -248,6 +248,17 @@ ext:conceptSchemeSelectorField a form:Field ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:conceptSchemeSelectorField .
+
+ext:conceptSchemeSelectorWithFormOptionPredicatesField a form:Field ;
+    sh:name "Select with form options" ;
+    sh:order 270 ;
+    sh:path ext:conceptSchemeSelectorValue ;
+    formOption:conceptScheme exampleConceptSchemes:foo-bar-baz ;
+    formOption:searchEnabled true ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group ext:mainPg .
+
+ext:mainFg form:hasField ext:conceptSchemeSelectorWithFormOptionPredicatesField .
 
 ##########################################################
 # Multi selector


### PR DESCRIPTION
Support form:options on a field but also form options as separate predicates e.g. formOption:conceptScheme.  

Other way of implementing https://github.com/lblod/ember-submission-form-fields/pull/188