### PR TITLE
bugfix allow clearing of numerical-input

### DIFF
--- a/addon/components/rdf-input-fields/numerical-input.js
+++ b/addon/components/rdf-input-fields/numerical-input.js
@@ -10,9 +10,15 @@ export default class RdfInputFieldsNumericalInputComponent extends SimpleInputFi
   @action
   updateValue(e) {
     if (e && typeof e.preventDefault === 'function') e.preventDefault();
-    this.value = e.target.value;
-    const number = literal(Number(this.value), this.datatype);
-    super.updateValue(number);
+    const value = e.target.value;
+    if (!value) {
+      this.value = null;
+      super.updateValue(null);
+    } else {
+      this.value = value;
+      const number = literal(Number(this.value), this.datatype);
+      super.updateValue(number);
+    }
   }
 
   get datatype() {


### PR DESCRIPTION
Before clearing a numerical-input component resulted in the value being zero.
Now it is actually possible to clear to value to null, which means the triple gets deleted.