### PR TITLE
LMB-326: update the uri to form-field-options

### DIFF
--- a/addon/utils/namespaces.js
+++ b/addon/utils/namespaces.js
@@ -1,5 +1,5 @@
 import { Namespace } from 'rdflib';
 
 export const FIELD_OPTION = new Namespace(
-  'http://lblod.data.gift/vocabularies/field-options/'
+  'http://lblod.data.gift/vocabularies/form-field-options/'
 );

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -11,7 +11,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
 @prefix eurio: <http://data.europa.eu/s66#> .
-@prefix fieldOption: <http://lblod.data.gift/vocabularies/field-options/> .
+@prefix fieldOption: <http://lblod.data.gift/vocabularies/form-field-options/> .
 @prefix exampleConceptSchemes: <http://example-concept-schemes/concept-schemes/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 


### PR DESCRIPTION
We have set the uri for field options wrong so we need to update it now as it is not used yet. 

Change the fieldOptions uri to `form-field-options`

```
@prefix fieldOption: <http://lblod.data.gift/vocabularies/form-field-options/> .
```