### PR TITLE
Ensure searchEnabled option may be left unspecified for concept-scheme-selector components

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -54,8 +54,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      this.searchEnabled = false;
-      if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
+      if (fieldOptions.searchEnabled !== undefined) {
         this.searchEnabled = fieldOptions.searchEnabled;
       }
     } else {

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -38,23 +38,26 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
+
+    // Note: a mix of old spec and new spec is possible here.
+    // Maybe add validation to enforce useage of one of the two specifications.
     let { conceptScheme, isSearchEnabled } = this.getFieldOptionsByPredicates();
 
+    // New form-spec for conceptScheme didn't yield result; trying old form-spec
     if (!conceptScheme) {
       if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
+        // No conceptScheme found hence this component can't work.
         return;
       }
       conceptScheme = new namedNode(fieldOptions.conceptScheme);
     }
 
-    /**
-     * NOTE: Most forms are now implemented to have a default "true" behavior
-     */
+    // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      if (!hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
-        return;
+      this.searchEnabled  = false;
+      if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
+        this.searchEnabled = fieldOptions.searchEnabled;
       }
-      this.searchEnabled = fieldOptions.searchEnabled;
     } else {
       this.searchEnabled = Literal.toJS(isSearchEnabled);
     }

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -54,7 +54,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      this.searchEnabled  = false;
+      this.searchEnabled = false;
       if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
         this.searchEnabled = fieldOptions.searchEnabled;
       }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -50,7 +50,10 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      this.searchEnabled = fieldOptions.searchEnabled || false;
+      this.searchEnabled  = false;
+      if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
+        this.searchEnabled = fieldOptions.searchEnabled;
+      }
     } else {
       this.searchEnabled = Literal.toJS(isSearchEnabled);
     }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -34,19 +34,23 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
+
+    // Note: a mix of old spec and new spec is possible here.
+    // Maybe add validation to enforce useage of one of the two specifications.
     let { conceptScheme, isSearchEnabled } = this.getFieldOptionsByPredicates();
 
+    // New form-spec for conceptScheme didn't yield result; trying old form-spec
     if (!conceptScheme) {
       if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
+        // No conceptScheme found hence this component can't work.
         return;
       }
       conceptScheme = new namedNode(fieldOptions.conceptScheme);
     }
 
-    /**
-     * NOTE: Most forms are now implemented to have a default "true" behavior
-     */
+    // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
+      this.searchEnabled = fieldOptions.searchEnabled || false;
     } else {
       this.searchEnabled = Literal.toJS(isSearchEnabled);
     }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -47,10 +47,6 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
      * NOTE: Most forms are now implemented to have a default "true" behavior
      */
     if (!isSearchEnabled) {
-      if (!hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
-        return;
-      }
-      this.searchEnabled = fieldOptions.searchEnabled;
     } else {
       this.searchEnabled = Literal.toJS(isSearchEnabled);
     }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -50,7 +50,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      this.searchEnabled  = false;
+      this.searchEnabled = false;
       if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
         this.searchEnabled = fieldOptions.searchEnabled;
       }

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -50,8 +50,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.
     if (!isSearchEnabled) {
-      this.searchEnabled = false;
-      if (hasValidFieldOptions(this.args.field, ['searchEnabled'])) {
+      if (fieldOptions.searchEnabled !== undefined) {
         this.searchEnabled = fieldOptions.searchEnabled;
       }
     } else {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -75,6 +75,13 @@
                   Tables
                 </AuNavigationLink>
               </li>
+
+              <li class="au-c-list-navigation__item">
+                <AuNavigationLink @route="form" @model="concept-scheme-selectors">
+                  Concept Scheme selectors
+                </AuNavigationLink>
+              </li>
+
             </ul>
           </nav>
         </div>

--- a/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
+++ b/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
@@ -1,0 +1,63 @@
+@prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix displayTypes: <http://lblod.data.gift/display-types/> .
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix sections: <http://data.lblod.info/fields/sections/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+##########################################################
+# form
+##########################################################
+
+form:main a form:Form, form:TopLevelForm ;
+    form:includes sections:main ;
+    form:includes fields:main-star-no-search-old;
+    form:includes fields:main-star-search-old;
+    form:includes fields:main-star-no-search-new;
+    form:includes fields:main-star-search-new.
+
+##########################################################
+#  property-group
+##########################################################
+sections:singleCodelist a form:Section;
+    sh:description "parent property-group, used to group fields and property-groups together";
+    sh:name "Single code list value" ;
+    sh:order 1 .
+
+##########################################################
+# Dropdown
+##########################################################
+fields:main-star-no-search-old a form:Field ;
+    sh:name "Rating 1: Old version ConceptSchemeSelector, `searchEnabled` not specified. " ;
+    sh:order 101 ;
+    sh:path ext:rating_1 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:partOf sections:singleCodelist .
+
+
+fields:main-star-search-old a form:Field ;
+    sh:name "Rating 2: Old version ConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:order 102 ;
+    sh:path ext:rating_2 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":true}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:partOf sections:singleCodelist .
+
+fields:main-star-no-search-new a form:Field ;
+    sh:name "Rating 3: New version ConceptSchemeSelector, `searchEnabled` not specified. " ;
+    sh:order 103 ;
+    sh:path ext:rating_3 ;
+    <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:partOf sections:singleCodelist .
+
+fields:main-star-search-new a form:Field ;
+    sh:name "Rating 4: New version ConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:order 104 ;
+    sh:path ext:rating_4 ;
+    <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "true"^^xsd:boolean;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    form:partOf sections:singleCodelist .

--- a/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
+++ b/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
@@ -39,10 +39,10 @@ fields:main-star-no-search-old a form:Field ;
 
 
 fields:main-star-search-old a form:Field ;
-    sh:name "Rating 2: Old version ConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:name "Rating 2: Old version ConceptSchemeSelector, `searchEnabled` specified to false. " ;
     sh:order 102 ;
     sh:path ext:rating_2 ;
-    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":true}""" ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":false}""" ;
     form:displayType displayTypes:conceptSchemeSelector ;
     form:partOf sections:singleCodelist .
 
@@ -55,11 +55,11 @@ fields:main-star-no-search-new a form:Field ;
     form:partOf sections:singleCodelist .
 
 fields:main-star-search-new a form:Field ;
-    sh:name "Rating 4: New version ConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:name "Rating 4: New version ConceptSchemeSelector, `searchEnabled` specified to false. " ;
     sh:order 104 ;
     sh:path ext:rating_4 ;
     <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
-    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "true"^^xsd:boolean;
+    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "false"^^xsd:boolean;
     form:displayType displayTypes:conceptSchemeSelector ;
     form:partOf sections:singleCodelist .
 
@@ -80,10 +80,10 @@ fields:multi-main-star-no-search-old a form:Field ;
 
 
 fields:multi-main-star-search-old a form:Field ;
-    sh:name "Rating 2: Old version MultiConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:name "Rating 2: Old version MultiConceptSchemeSelector, `searchEnabled` specified to false. " ;
     sh:order 102 ;
     sh:path ext:rating_multi_2 ;
-    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":true}""" ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":false}""" ;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
     form:partOf sections:multiCodelist .
 
@@ -96,10 +96,10 @@ fields:multi-main-star-no-search-new a form:Field ;
     form:partOf sections:multiCodelist .
 
 fields:multi-main-star-search-new a form:Field ;
-    sh:name "Rating 4: New version MultiConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:name "Rating 4: New version MultiConceptSchemeSelector, `searchEnabled` specified to false. " ;
     sh:order 104 ;
     sh:path ext:rating_multi_4 ;
     <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
-    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "true"^^xsd:boolean;
+    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "false"^^xsd:boolean;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
     form:partOf sections:multiCodelist .

--- a/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
+++ b/tests/dummy/public/test-forms/concept-scheme-selectors/form.ttl
@@ -15,19 +15,20 @@ form:main a form:Form, form:TopLevelForm ;
     form:includes fields:main-star-no-search-old;
     form:includes fields:main-star-search-old;
     form:includes fields:main-star-no-search-new;
-    form:includes fields:main-star-search-new.
+    form:includes fields:main-star-search-new;
+    form:includes sections:multiCodelist;
+    form:includes fields:multi-main-star-no-search-old;
+    form:includes fields:multi-main-star-search-old;
+    form:includes fields:multi-main-star-no-search-new;
+    form:includes fields:multi-main-star-search-new.
 
 ##########################################################
-#  property-group
+# Start: SINGLE CODELIST
 ##########################################################
 sections:singleCodelist a form:Section;
-    sh:description "parent property-group, used to group fields and property-groups together";
     sh:name "Single code list value" ;
     sh:order 1 .
 
-##########################################################
-# Dropdown
-##########################################################
 fields:main-star-no-search-old a form:Field ;
     sh:name "Rating 1: Old version ConceptSchemeSelector, `searchEnabled` not specified. " ;
     sh:order 101 ;
@@ -61,3 +62,44 @@ fields:main-star-search-new a form:Field ;
     <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "true"^^xsd:boolean;
     form:displayType displayTypes:conceptSchemeSelector ;
     form:partOf sections:singleCodelist .
+
+##########################################################
+# Start: MULTI CODELIST
+##########################################################
+sections:multiCodelist a form:Section;
+    sh:name "Multi code list value" ;
+    sh:order 2 .
+
+fields:multi-main-star-no-search-old a form:Field ;
+    sh:name "Rating 1: Old version MultiConceptSchemeSelector, `searchEnabled` not specified. " ;
+    sh:order 101 ;
+    sh:path ext:rating_multi_1 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a"}""" ;
+    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:partOf sections:multiCodelist .
+
+
+fields:multi-main-star-search-old a form:Field ;
+    sh:name "Rating 2: Old version MultiConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:order 102 ;
+    sh:path ext:rating_multi_2 ;
+    form:options """{"conceptScheme":"http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a","searchEnabled":true}""" ;
+    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:partOf sections:multiCodelist .
+
+fields:multi-main-star-no-search-new a form:Field ;
+    sh:name "Rating 3: New version MultiConceptSchemeSelector, `searchEnabled` not specified. " ;
+    sh:order 103 ;
+    sh:path ext:rating_multi_3 ;
+    <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:partOf sections:multiCodelist .
+
+fields:multi-main-star-search-new a form:Field ;
+    sh:name "Rating 4: New version MultiConceptSchemeSelector, `searchEnabled` specified to true. " ;
+    sh:order 104 ;
+    sh:path ext:rating_multi_4 ;
+    <http://lblod.data.gift/vocabularies/form-field-options/conceptScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://lblod.data.gift/vocabularies/form-field-options/searchEnabled> "true"^^xsd:boolean;
+    form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:partOf sections:multiCodelist .

--- a/tests/dummy/public/test-forms/concept-scheme-selectors/meta.ttl
+++ b/tests/dummy/public/test-forms/concept-scheme-selectors/meta.ttl
@@ -1,0 +1,39 @@
+<http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>
+    a <http://www.w3.org/2004/02/skos/core#ConceptScheme>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "21d1250c-6627-4111-934f-f2f7bd8c078a" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Star Rating"@en.
+
+<http://redpencil.data.gift/concepts/a6e5bd0c-c200-4834-99b3-e80198672628>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "a6e5bd0c-c200-4834-99b3-e80198672628" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "5 stars"@en;
+    <http://purl.org/linked-data/cube#order> 5.
+
+<http://redpencil.data.gift/concepts/df2b8b6e-bcc2-4608-83da-98ab251fcf54>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "df2b8b6e-bcc2-4608-83da-98ab251fcf54" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "4 stars"@en;
+    <http://purl.org/linked-data/cube#order> 4.
+
+<http://redpencil.data.gift/concepts/d3bcb263-c4e4-4512-98c8-d0b45400eebd>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "d3bcb263-c4e4-4512-98c8-d0b45400eebd" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "3 stars"@en;
+    <http://purl.org/linked-data/cube#order> 3.
+
+<http://redpencil.data.gift/concepts/0d5b3b23-c055-4d56-83d0-b65d28050315>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "0d5b3b23-c055-4d56-83d0-b65d28050315" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "2 stars"@en;
+    <http://purl.org/linked-data/cube#order> 2.
+
+<http://redpencil.data.gift/concepts/1770b75a-95d7-4087-93d6-2c9322b7dfee>
+    a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "1770b75a-95d7-4087-93d6-2c9322b7dfee" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://redpencil.data.gift/concept-schemes/21d1250c-6627-4111-934f-f2f7bd8c078a>;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "1 star"@en;
+    <http://purl.org/linked-data/cube#order> 1.


### PR DESCRIPTION
In a recent release, `searchEnabled` has been unintentionally changed from an optional parameter to a required parameter.
This was a breaking change. Also, it's easier for whoever specifies the form to not have to explicitly define this parameter.
The fix has been pushed to both single selector and multi selector.
Some dummy forms have been added to ease testing.
See also DGS-342.
