### PR TITLE
optionally use lazy generators

### DIFF
--- a/addon/components/rdf-form.js
+++ b/addon/components/rdf-form.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import {
   generatorsForNode,
   triplesForGenerator,
+  triplesForLazyGenerator,
 } from '@lblod/submission-form-helpers';
 import { getRootNodeForm, getTopLevelSections } from '../utils/model-factory';
 import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
@@ -38,7 +39,11 @@ export default class RdfForm extends Component {
     });
 
     if (generators.initGenerators.length) {
-      const dataset = triplesForGenerator(generators.initGenerators[0], {
+      let generatorFunction = triplesForGenerator;
+      if (this.args.lazyGenerators) {
+        generatorFunction = triplesForLazyGenerator;
+      }
+      const dataset = generatorFunction(generators.initGenerators[0], {
         store,
         sourceNode,
         formGraph: graphs.formGraph,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@embroider/macros": "^1.13.5",
-        "@lblod/submission-form-helpers": "^2.9.0",
+        "@lblod/submission-form-helpers": "^2.10.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^3.0.0",
         "ember-auto-import": "^2.7.2",
@@ -3701,9 +3701,9 @@
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.9.0.tgz",
-      "integrity": "sha512-TrXD+Zaizbkov4iYQAIKsxeGx5g+jq+kdkXQXkmPXubMYyPfxoZCAzwtM5fEoSe8wB5KSjmwW2jNPg40S7ZzMw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.2.tgz",
+      "integrity": "sha512-ftc5T/sLpXFvRIdPR0QlZybQJJAoTleo1l6lEZ35ezuXG3h915G+WeCuq+PZMyPGo9d3deGE4pDA5H0D4q8qVQ==",
       "dependencies": {
         "iban": "0.0.14",
         "libphonenumber-js": "^1.9.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.13.5",
-    "@lblod/submission-form-helpers": "^2.9.0",
+    "@lblod/submission-form-helpers": "^2.10.2",
     "client-zip": "^2.4.4",
     "clipboardy": "^3.0.0",
     "ember-auto-import": "^2.7.2",


### PR DESCRIPTION
this allows forms to specify that they'd like to use the lazy generators that reuse the heads of the paths in the generator shapes if they exist and generate new uris for the tail ends of the paths that don't.
That way, if a generator has run and the form source data already contains generated instances, they are not generated again but rather reused.

This is completely optional and is done by setting `@lazyGenerators={{true}}` in the template