### PR TITLE
Fix "true" value handling in boolean components (checkbox/switch)

### DIFF
--- a/addon/components/rdf-input-fields/checkbox.js
+++ b/addon/components/rdf-input-fields/checkbox.js
@@ -9,7 +9,9 @@ export default class RdfInputFieldsCheckboxComponent extends SimpleInputFieldCom
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
-      this.value = matches.values[0].value === '1'; // There is a bug in conversion from rdflib
+      // There is a bug in conversion from rdflib
+      this.value =
+        matches.values[0].value === '1' || matches.values[0].value === 'true';
     }
   }
 

--- a/addon/components/rdf-input-fields/checkbox.js
+++ b/addon/components/rdf-input-fields/checkbox.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
+import { Literal } from 'rdflib';
 
 // Note : default values are not working yet with this component, loadProvidedValue is overriden
 
@@ -9,9 +10,7 @@ export default class RdfInputFieldsCheckboxComponent extends SimpleInputFieldCom
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
-      // There is a bug in conversion from rdflib
-      this.value =
-        matches.values[0].value === '1' || matches.values[0].value === 'true';
+      this.value = Literal.toJS(this.nodeValue);
     }
   }
 

--- a/addon/components/rdf-input-fields/switch.js
+++ b/addon/components/rdf-input-fields/switch.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { triplesForPath } from '@lblod/submission-form-helpers';
+import { Literal } from 'rdflib';
 
 // Note : default values are not working yet with this component, loadProvidedValue is overriden
 
@@ -12,9 +13,7 @@ export default class FormInputFieldsSwitchEditComponent extends SimpleInputField
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
-      // There is a bug in conversion from rdflib
-      this.value =
-        matches.values[0].value === '1' || matches.values[0].value === 'true';
+      this.value = Literal.toJS(this.nodeValue);
     }
   }
 

--- a/addon/components/rdf-input-fields/switch.js
+++ b/addon/components/rdf-input-fields/switch.js
@@ -12,7 +12,9 @@ export default class FormInputFieldsSwitchEditComponent extends SimpleInputField
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {
       this.nodeValue = matches.values[0];
-      this.value = matches.values[0].value === '1'; // There is a bug in conversion from rdflib
+      // There is a bug in conversion from rdflib
+      this.value =
+        matches.values[0].value === '1' || matches.values[0].value === 'true';
     }
   }
 


### PR DESCRIPTION
When creating a new entity with a form, a boolean value will be send as object `true` (which is valid ttl syntax).
Interestingly, when updating an entity (which would happen via a PUT request), the ttl will instead use `"true"^^xsd:boolean`. (as far as I could find, also valid).

When requesting the boolean value, the same syntax (`"true"^^xsd:boolean`) is used, but the boolean-aware components expect (`"1"^^xsd:boolean`). This makes it so they can handle both "true" and "1".
Fixing it here seemed the most logical.

some helper function might make sense, so it can also be used by developers creating custom components?