### PR TITLE
Allow HTML to be rendered in alert

### DIFF
--- a/addon/components/rdf-input-fields/alert.hbs
+++ b/addon/components/rdf-input-fields/alert.hbs
@@ -6,5 +6,6 @@
   @skin={{this.options.skin}}
   class="au-u-margin-bottom-none"
 >
-  {{@field.label}}
+  {{! template-lint-disable no-triple-curlies}}
+  {{{@field.label}}}
 </AuAlert>


### PR DESCRIPTION
Allow HTML to be rendered in alert component.

HTML should only be coming from the semantic forms and never contain user input in any way. Allowing HTML to be rendered was already done in some places, e.g. https://github.com/lblod/ember-submission-form-fields/blob/e917435aae617b72c5143f04a211d46da99129bf/addon/components/submission-form.hbs#L27

**TODO: (before or after the PR review/merge?)**

* Update the CHANGELOG
* Prepare a release