### PR TITLE
[DL-5449] Fix an issue with the "RemoteUrl" field

### DIFF
--- a/addon/components/rdf-input-fields/remote-urls/edit.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/edit.hbs
@@ -42,7 +42,13 @@
             @skin="link"
             @icon="bin"
             @iconAlignment="left"
-            {{on "click" (fn this.removeRemoteUrl remoteUrl)}}
+            {{!template-lint-disable no-pointer-down-event-binding}}
+            {{!
+              We use the mousedown event because it is triggered before the `blur` event of the input element.
+              This is needed because the blur event displays validation messages if the input is empty which displace the button
+              and as a result, the click event wouldn't be triggered.
+            }}
+            {{on "mousedown" (fn this.removeRemoteUrl remoteUrl)}}
           >
             Verwijder&nbsp;link
           </AuButton>


### PR DESCRIPTION
When the user creates a new link and then immediately clicks the delete button nothing happens. The user has to click the button a second time.

The reason for this is that we use the blur event on the input field to handle validations and this event is triggered _before_ the click event of the button. Because the field is empty, error messages are displayed and the button is pushed down and because of that displacement the click event isn't triggered.

By switching to the `mousedown` event the removal happens before the blur event is triggered, which sidesteps the problem.

**To test**
1. Add the following validators to the remoteUrls field in the `basic-fields/form.ttl` file.
```ttl
    form:validations
     [ a form:UriConstraint ;
        form:grouping form:MatchEvery ;
        sh:resultMessage "Gelieve een geldige URL op te geven. Zorg dat vooraan in de link altijd http://, https://, ftp:// of sftp:// staat."; # TODO: later custom validator
         sh:path ( dct:hasPart nie:url ) ],
     [ a form:RequiredConstraint ;
         form:grouping form:Bag ;
         sh:path ( dct:hasPart nie:url ) ;
         sh:resultMessage "Gelieve minstens één URL op te geven."@nl
     ];
```
2. Add a new link
3. Delete the link again (while the input is focused and empty)
4. This should remove the link without having to click the button a second time