### PR TITLE
Fix the Embroider test scenarios

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -54,5 +54,16 @@ module.exports = function (defaults) {
       },
     ],
     compatAdapters,
+    packagerOptions: {
+      webpackConfig: {
+        resolve: {
+          fallback: {
+            // @frogcat/ttl2jsonld (which is a dependency of rdflib) conditionally requires this here: https://github.com/frogcat/ttl2jsonld/blob/686ae54dd13c5769750a0dd879c5551c8e1ca7ad/ttl2jsonld.js#L4617
+            // We disable this import for our test app, but it's likely that consuming apps will also run into this, so we should find a solution, or document that this is needed.
+            url: false,
+          },
+        },
+      },
+    },
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.0.1",
         "@ember/test-helpers": "^2.9.3",
-        "@embroider/test-setup": "^3.0.3",
+        "@embroider/test-setup": "^4.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "broccoli-asset-rev": "^3.0.0",
@@ -3169,9 +3169,9 @@
       }
     },
     "node_modules/@embroider/test-setup": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-3.0.3.tgz",
-      "integrity": "sha512-3K5KSyTdnxAkZQill6+TdC/XTRr6226LNwZMsrhRbBM0FFZXw2D8qmJSHPvZLheQx3A1jnF9t1lyrAzrKlg6Yw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@embroider/test-setup/-/test-setup-4.0.0.tgz",
+      "integrity": "sha512-1S3Ebk0CEh3XDqD93AWSwQZBCk+oGv03gtkaGgdgyXGIR7jrVyDgEnEuslN/hJ0cuU8TqhiXrzHMw7bJwIGhWw==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21",
@@ -3181,9 +3181,9 @@
         "node": "12.* || 14.* || >= 16"
       },
       "peerDependencies": {
-        "@embroider/compat": "^3.3.0",
-        "@embroider/core": "^3.4.0",
-        "@embroider/webpack": "^3.2.1"
+        "@embroider/compat": "^3.4.8",
+        "@embroider/core": "^3.4.8",
+        "@embroider/webpack": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "@embroider/compat": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
-    "@embroider/test-setup": "^3.0.3",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
The Embroider scenarios have been failing since we released Appuniversum v3.7.0. It _seems_ that the removal of ember-data-table (which depends on ember-auto-import v1 and Webpack v4) causes the build error to appear. It shouldn't since we were using Webpack v5 already, but maybe something was still being polyfilled by accident because it was Webpack v4 was present in the dep tree.

By adding this Webpack config to the test app things should start working again, but consuming apps might run into the same problem.. I don't think we can configure the app's Embroider config from the addon, so we would either have to document what's needed for Embroider to work, or export some sort of config object they can use. Ideally the ttl2jsonld wouldn't require the `url` package like that and make a build for browsers but that package doesn't seem maintained..