### PR TITLE
Add a new `helpTextBelowLabel` build option

### DIFF
--- a/addon/components/form-section.hbs
+++ b/addon/components/form-section.hbs
@@ -74,10 +74,13 @@
               />
             {{/let}}
 
-            {{#if field.help}}
-              {{! template-lint-disable no-triple-curlies}}
-              <AuHelpText>{{{field.help}}}</AuHelpText>
-            {{/if}}
+            {{! template-lint-disable simple-unless}}
+            {{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+              {{#if field.help}}
+                {{! template-lint-disable no-triple-curlies}}
+                <AuHelpText>{{{field.help}}}</AuHelpText>
+              {{/if}}
+            {{/unless}}
           </div>
         {{/if}}
       {{/if}}

--- a/addon/components/private/help-text.hbs
+++ b/addon/components/private/help-text.hbs
@@ -1,0 +1,8 @@
+{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+  {{#if @field.help}}
+    {{! template-lint-disable no-triple-curlies}}
+    <AuHelpText
+      class="au-u-margin-top-none au-u-margin-bottom-tiny"
+    >{{{@field.help}}}</AuHelpText>
+  {{/if}}
+{{/if}}

--- a/addon/components/rdf-input-fields/alert.hbs
+++ b/addon/components/rdf-input-fields/alert.hbs
@@ -1,3 +1,4 @@
+<this.HelpText @field={{@field}} />
 <AuAlert
   @title={{this.options.title}}
   @icon={{this.options.icon}}

--- a/addon/components/rdf-input-fields/alert.js
+++ b/addon/components/rdf-input-fields/alert.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 
 export default class AlertComponent extends Component {
+  HelpText = HelpText;
   get options() {
     return this.args.field.options;
   }

--- a/addon/components/rdf-input-fields/case-number.hbs
+++ b/addon/components/rdf-input-fields/case-number.hbs
@@ -1,4 +1,11 @@
-<AuLabel for={{this.id}}>{{@field.label}}</AuLabel>
+<AuLabel
+  for={{this.id}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
+>{{@field.label}}</AuLabel>
+<this.HelpText @field={{@field}} />
 {{#if this.showAlert}}
   <AuAlert
     @icon="alert-triangle"

--- a/addon/components/rdf-input-fields/case-number.js
+++ b/addon/components/rdf-input-fields/case-number.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import clipboardy from 'clipboardy';
 
 /**
@@ -35,6 +36,7 @@ import clipboardy from 'clipboardy';
  */
 export default class RdfInputFieldsCaseNumberComponent extends SimpleInputFieldComponent {
   id = 'case-number-' + guidFor(this);
+  HelpText = HelpText;
 
   @tracked error;
 

--- a/addon/components/rdf-input-fields/checkbox.hbs
+++ b/addon/components/rdf-input-fields/checkbox.hbs
@@ -11,6 +11,9 @@
     {{/if}}
   </div>
 {{/if}}
+
+<this.HelpText @field={{@field}} />
+
 <AuCheckbox
   @checked={{this.value}}
   @disabled={{@show}}

--- a/addon/components/rdf-input-fields/checkbox.js
+++ b/addon/components/rdf-input-fields/checkbox.js
@@ -1,11 +1,13 @@
 import { action } from '@ember/object';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { Literal } from 'rdflib';
 
 // Note : default values are not working yet with this component, loadProvidedValue is overriden
 
 export default class RdfInputFieldsCheckboxComponent extends SimpleInputFieldComponent {
+  HelpText = HelpText;
   loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);
     if (matches.values.length > 0) {

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
@@ -1,4 +1,10 @@
-<AuFieldset as |f|>
+<AuFieldset
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "sf-u-gap-initial"
+  }}
+  as |f|
+>
   <f.legend
     @required={{this.isRequired}}
     @requiredLabel={{this.requiredLabel}}
@@ -8,13 +14,14 @@
     {{@field.label}}
   </f.legend>
   <f.content class="concept-scheme-multi-select-checkboxes__content">
+    <this.HelpText @field={{@field}} />
     <div class="au-o-grid au-o-grid--flush">
       {{#each this.options as |option|}}
         <div
           class="au-o-grid__item
             {{if
               this.isColumnLayout
-              "au-u-1-1@tiny au-u-1-2@small au-u-1-3@medium"
+              'au-u-1-1@tiny au-u-1-2@small au-u-1-3@medium'
             }}"
         >
           <AuCheckbox

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import {
   addSimpleFormValue,
@@ -13,6 +14,7 @@ import { FIELD_OPTION } from '../../utils/namespaces';
 
 export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent extends InputFieldComponent {
   @tracked options = [];
+  HelpText = HelpText;
 
   constructor() {
     super(...arguments);

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
@@ -3,9 +3,16 @@
   @warnings={{this.hasWarnings}}
   @required={{this.isRequired}}
   for={{this.inputId}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
 >
   {{@field.label}}
 </AuLabel>
+
+<this.HelpText @field={{@field}} />
+
 <div class={{if this.hasErrors "ember-power-select--error"}}>
   <PowerSelectMultiple
     @triggerId={{this.inputId}}

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -7,6 +7,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { Literal, NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
@@ -20,6 +21,7 @@ function byLabel(a, b) {
 
 export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
+  HelpText = HelpText;
 
   @tracked selected = null;
   @tracked options = [];

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
@@ -1,4 +1,10 @@
-<AuFieldset as |f|>
+<AuFieldset
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "sf-u-gap-initial"
+  }}
+  as |f|
+>
   <f.legend
     @required={{this.isRequired}}
     @error={{this.hasErrors}}
@@ -7,6 +13,7 @@
     {{@field.label}}
   </f.legend>
   <f.content>
+    <this.HelpText @field={{@field}} />
     <ul>
       {{#each this.options as |option|}}
         <li>

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { SKOS } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
@@ -8,6 +9,7 @@ import { FIELD_OPTION } from '../../utils/namespaces';
 
 export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends SimpleInputFieldComponent {
   @tracked options = [];
+  HelpText = HelpText;
 
   constructor() {
     super(...arguments);

--- a/addon/components/rdf-input-fields/concept-scheme-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.hbs
@@ -4,9 +4,14 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
   </AuLabel>
+  <this.HelpText @field={{@field}} />
 {{/unless}}
 <div class={{if this.hasErrors "ember-power-select--error"}}>
   <PowerSelect

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import {
   SKOS,
   triplesForPath,
@@ -19,6 +20,7 @@ function byLabel(a, b) {
 
 export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
+  HelpText = HelpText;
 
   @tracked selected = null;
   @tracked options = [];

--- a/addon/components/rdf-input-fields/currency-input.hbs
+++ b/addon/components/rdf-input-fields/currency-input.hbs
@@ -4,9 +4,14 @@
     @warning={{this.hasWarnings}}
     @required={{this.isRequired}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
   </AuLabel>
+  <this.HelpText @field={{@field}} />
 {{/unless}}
 
 <div class="currency-input">

--- a/addon/components/rdf-input-fields/currency-input.js
+++ b/addon/components/rdf-input-fields/currency-input.js
@@ -1,12 +1,13 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { XSD } from '@lblod/submission-form-helpers';
 import { literal } from 'rdflib';
 
 export default class RdfInputFieldsCurrencyInputComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
-
+  HelpText = HelpText;
   currencyIsocode = 'EUR';
 
   @action

--- a/addon/components/rdf-input-fields/date-picker.hbs
+++ b/addon/components/rdf-input-fields/date-picker.hbs
@@ -3,9 +3,27 @@
   @required={{this.isRequired}}
   @warning={{this.hasWarnings}}
   for={{this.inputId}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
 >
   {{@field.label}}
 </AuLabel>
+
+<this.HelpText @field={{@field}} />
+
+{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+  {{#unless @show}}
+    <AuHelpText
+      @error={{this.hasErrors}}
+      class="au-u-margin-top-none au-u-margin-bottom-tiny"
+    >
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/unless}}
+{{/if}}
+
 <div class="au-o-grid au-o-grid--flush">
   <div class="au-o-grid__item au-u-3-4">
     <AuDatePicker
@@ -20,10 +38,13 @@
   </div>
 </div>
 
-{{#unless @show}}
-  <AuHelpText @error={{this.hasErrors}}>
-    Datum formaat: DD-MM-JJJJ
-  </AuHelpText>
+{{!template-lint-disable simple-unless}}
+{{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+  {{#unless @show}}
+    <AuHelpText @error={{this.hasErrors}}>
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/unless}}
 {{/unless}}
 
 {{#each this.errors as |error|}}

--- a/addon/components/rdf-input-fields/date-picker.js
+++ b/addon/components/rdf-input-fields/date-picker.js
@@ -2,10 +2,12 @@ import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import { XSD } from '@lblod/submission-form-helpers';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { literal } from 'rdflib';
 
 export default class RdfInputFieldsDatePickerComponent extends SimpleInputFieldComponent {
   inputId = 'date-' + guidFor(this);
+  HelpText = HelpText;
 
   @action
   updateValue(isoDate) {

--- a/addon/components/rdf-input-fields/date-range.hbs
+++ b/addon/components/rdf-input-fields/date-range.hbs
@@ -1,4 +1,12 @@
-<AuLabel>{{@field.label}}</AuLabel>
+<AuLabel
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
+>{{@field.label}}</AuLabel>
+
+<this.HelpText @field={{@field}} />
+
 <AuButtonGroup @inline={{true}}>
   <AuButton
     @skin={{if this.isEnabled "secondary"}}

--- a/addon/components/rdf-input-fields/date-range.js
+++ b/addon/components/rdf-input-fields/date-range.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { SHACL } from '@lblod/submission-form-helpers';
 import { Namespace } from 'rdflib';
 
@@ -12,6 +13,7 @@ const DATE_RANGE = new Namespace(
 export default class RdfInputFieldsDateRangeComponent extends SimpleInputFieldComponent {
   inputId = 'date-range-from' + guidFor(this);
   inputIdTo = `date-range-to-${guidFor(this)}`;
+  HelpText = HelpText;
 
   @tracked from;
   @tracked to;

--- a/addon/components/rdf-input-fields/date-time.hbs
+++ b/addon/components/rdf-input-fields/date-time.hbs
@@ -3,9 +3,27 @@
   @required={{this.isRequired}}
   @warning={{this.hasWarnings}}
   for={{this.inputId}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
 >
   {{@field.label}}
 </AuLabel>
+
+<this.HelpText @field={{@field}} />
+
+{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+  {{#unless @show}}
+    <AuHelpText
+      @error={{this.hasErrors}}
+      class="au-u-margin-top-none au-u-margin-bottom-tiny"
+    >
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/unless}}
+{{/if}}
+
 <div class="au-o-grid au-o-grid--flush">
   <div class="au-o-grid__item au-u-3-4">
     <AuDateInput
@@ -18,10 +36,13 @@
       {{on "blur" (fn (mut this.hasBeenFocused) true)}}
     />
 
-    {{#unless @show}}
-      <AuHelpText @error={{this.hasErrors}}>
-        Datum formaat: DD-MM-JJJJ
-      </AuHelpText>
+    {{!template-lint-disable simple-unless}}
+    {{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+      {{#unless @show}}
+        <AuHelpText @error={{this.hasErrors}}>
+          Datum formaat: DD-MM-JJJJ
+        </AuHelpText>
+      {{/unless}}
     {{/unless}}
     {{#each this.errors as |error|}}
       <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/addon/components/rdf-input-fields/date-time.js
+++ b/addon/components/rdf-input-fields/date-time.js
@@ -2,11 +2,13 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { triplesForPath, XSD } from '@lblod/submission-form-helpers';
 import { literal } from 'rdflib';
 
 export default class RdfInputFieldsDateTimeComponent extends SimpleInputFieldComponent {
   inputId = 'date-time-' + guidFor(this);
+  HelpText = HelpText;
 
   @tracked value = null;
   @tracked hour = null;

--- a/addon/components/rdf-input-fields/date.hbs
+++ b/addon/components/rdf-input-fields/date.hbs
@@ -4,9 +4,25 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
   </AuLabel>
+  <this.HelpText @field={{@field}} />
+
+  {{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+    {{#unless @show}}
+      <AuHelpText
+        @error={{this.hasErrors}}
+        class="au-u-margin-top-none au-u-margin-bottom-tiny"
+      >
+        Datum formaat: DD-MM-JJJJ
+      </AuHelpText>
+    {{/unless}}
+  {{/if}}
 {{/unless}}
 <div class={{unless @inTable "au-o-grid au-o-grid--flush"}}>
   <div class={{unless @inTable "au-o-grid__item au-u-3-4"}}>
@@ -23,11 +39,14 @@
   </div>
 </div>
 
-{{#if (not (or @show @inTable))}}
-  <AuHelpText @error={{this.hasErrors}}>
-    Datum formaat: DD-MM-JJJJ
-  </AuHelpText>
-{{/if}}
+{{!template-lint-disable simple-unless}}
+{{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+  {{#if (not (or @show @inTable))}}
+    <AuHelpText @error={{this.hasErrors}}>
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/if}}
+{{/unless}}
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
 {{/each}}

--- a/addon/components/rdf-input-fields/date.js
+++ b/addon/components/rdf-input-fields/date.js
@@ -2,10 +2,12 @@ import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import { XSD } from '@lblod/submission-form-helpers';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { literal } from 'rdflib';
 
 export default class RdfInputFieldsDateComponent extends SimpleInputFieldComponent {
   inputId = 'date-' + guidFor(this);
+  HelpText = HelpText;
 
   @action
   updateValue(isoDate) {

--- a/addon/components/rdf-input-fields/files.hbs
+++ b/addon/components/rdf-input-fields/files.hbs
@@ -1,10 +1,11 @@
-<div class="au-u-flex au-u-flex--between au-u-margin-bottom">
+<div class="au-u-flex au-u-flex--between">
   <AuLabel
     @error={{this.hasErrors}}
     @required={{this.isRequired}}
     @requiredLabel={{if this.containsRemoteUrls "Enkel indien geen links"}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
+    class="au-u-margin-bottom-none"
   >
     {{@field.label}}
   </AuLabel>
@@ -20,6 +21,7 @@
     </AuButton>
   {{/if}}
 </div>
+<this.HelpText @field={{@field}} />
 
 {{#if this.loadProvidedValue.isIdle}}
   {{#if this.files}}

--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -5,6 +5,7 @@ import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import {
   addSimpleFormValue,
   FORM,
@@ -39,6 +40,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
   @service toaster;
   @tracked files = A();
   inputId = `files-${guidFor(this)}`; // TODO for now this doesn't work on the <AuFileUpload /> component.
+  HelpText = HelpText;
 
   constructor() {
     super(...arguments);

--- a/addon/components/rdf-input-fields/heading.hbs
+++ b/addon/components/rdf-input-fields/heading.hbs
@@ -1,3 +1,5 @@
 <AuHeading @level={{this.level}} @skin={{this.skin}}>
   {{@field.label}}
 </AuHeading>
+
+<this.HelpText @field={{@field}} />

--- a/addon/components/rdf-input-fields/heading.js
+++ b/addon/components/rdf-input-fields/heading.js
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 
 export default class RdfHeadingComponent extends Component {
+  HelpText = HelpText;
+
   get skin() {
     return this.args.field.options.skin;
   }

--- a/addon/components/rdf-input-fields/input.hbs
+++ b/addon/components/rdf-input-fields/input.hbs
@@ -4,6 +4,10 @@
     @warning={{this.hasWarnings}}
     @required={{this.isRequired}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
     {{#unless @show}}
@@ -15,6 +19,7 @@
       {{/if}}
     {{/unless}}
   </AuLabel>
+  <this.HelpText @field={{@field}} />
 {{/unless}}
 
 <AuInput

--- a/addon/components/rdf-input-fields/input.js
+++ b/addon/components/rdf-input-fields/input.js
@@ -1,9 +1,11 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 
 export default class RdfInputFieldsInputComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
+  HelpText = HelpText;
 
   @action
   updateValue(e) {

--- a/addon/components/rdf-input-fields/numerical-input.hbs
+++ b/addon/components/rdf-input-fields/numerical-input.hbs
@@ -4,9 +4,14 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
   </AuLabel>
+  <this.HelpText @field={{@field}} />
 {{/unless}}
 <AuInput
   @error={{this.hasErrors}}

--- a/addon/components/rdf-input-fields/numerical-input.js
+++ b/addon/components/rdf-input-fields/numerical-input.js
@@ -1,11 +1,13 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { XSD } from '@lblod/submission-form-helpers';
 import { literal } from 'rdflib';
 
 export default class RdfInputFieldsNumericalInputComponent extends SimpleInputFieldComponent {
   inputId = 'input-' + guidFor(this);
+  HelpText = HelpText;
 
   @action
   updateValue(e) {

--- a/addon/components/rdf-input-fields/remote-urls/edit.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/edit.hbs
@@ -4,9 +4,14 @@
   @requiredLabel={{@requiredLabel}}
   @warning={{this.hasWarnings}}
   for={{this.inputFor}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
 >
   {{@field.label}}
 </AuLabel>
+<this.HelpText @field={{@field}} />
 
 {{#if this.remoteUrls}}
   <ul class="au-o-flow au-o-flow--tiny">

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -12,6 +12,7 @@ import { NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { guidFor } from '@ember/object/internals';
 import { autofocus } from '../../../-private/modifiers/autofocus';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
 const REQUEST_HEADER = new NamedNode(
@@ -46,6 +47,7 @@ class RemoteUrl {
 export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldComponent {
   inputId = `remote-urls-${guidFor(this)}`;
   autofocus = autofocus;
+  HelpText = HelpText;
 
   get inputFor() {
     if (this.remoteUrls.length) {

--- a/addon/components/rdf-input-fields/search.hbs
+++ b/addon/components/rdf-input-fields/search.hbs
@@ -1,6 +1,13 @@
-<AuLabel for={{this.inputId}}>
+<AuLabel
+  for={{this.inputId}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
+>
   {{@field.label}}
 </AuLabel>
+<this.HelpText @field={{@field}} />
 <AuInput
   @width="block"
   @disabled={{@show}}

--- a/addon/components/rdf-input-fields/search.js
+++ b/addon/components/rdf-input-fields/search.js
@@ -1,9 +1,11 @@
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class RdfInputFieldsSearchComponent extends SimpleInputFieldComponent {
   inputId = 'search-' + guidFor(this);
+  HelpText = HelpText;
 
   search = restartableTask(async (event) => {
     await timeout(250);

--- a/addon/components/rdf-input-fields/switch.hbs
+++ b/addon/components/rdf-input-fields/switch.hbs
@@ -1,3 +1,4 @@
+<this.HelpText @field={{@field}} />
 <AuToggleSwitch
   @checked={{this.value}}
   @onChange={{this.updateValue}}

--- a/addon/components/rdf-input-fields/switch.js
+++ b/addon/components/rdf-input-fields/switch.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { triplesForPath } from '@lblod/submission-form-helpers';
 import { Literal } from 'rdflib';
 
@@ -8,6 +9,7 @@ import { Literal } from 'rdflib';
 
 export default class FormInputFieldsSwitchEditComponent extends SimpleInputFieldComponent {
   inputId = 'switch-' + guidFor(this);
+  HelpText = HelpText;
 
   loadProvidedValue() {
     const matches = triplesForPath(this.storeOptions);

--- a/addon/components/rdf-input-fields/text-area.hbs
+++ b/addon/components/rdf-input-fields/text-area.hbs
@@ -4,9 +4,15 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
+    class={{if
+      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+      "au-u-margin-bottom-none"
+    }}
   >
     {{@field.label}}
   </AuLabel>
+
+  <this.HelpText @field={{@field}} />
 
   {{#if @field.description}}
     <p class="au-u-light au-u-margin-bottom-tiny">{{@field.description}}</p>

--- a/addon/components/rdf-input-fields/text-area.js
+++ b/addon/components/rdf-input-fields/text-area.js
@@ -1,9 +1,11 @@
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 
 export default class RdfInputFieldsTextAreaComponent extends SimpleInputFieldComponent {
   inputId = 'textarea-' + guidFor(this);
+  HelpText = HelpText;
 
   @action
   updateValue(e) {

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
@@ -1,6 +1,13 @@
-<AuLabel @required={{this.isRequired}}>
+<AuLabel
+  @required={{this.isRequired}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
+>
   {{@field.label}}
 </AuLabel>
+<this.HelpText @field={{@field}} />
 
 {{#if this.showDifferentiatie}}
   <AuCheckbox

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.js
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { RDF, triplesForPath } from '@lblod/submission-form-helpers';
 import { NamedNode } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
@@ -40,6 +41,7 @@ class TaxEntry {
 export default class RdfInputFieldsVlabelOpcentiemComponent extends InputFieldComponent {
   amountColumnId = 'amount-column-' + guidFor(this);
   autofocus = autofocus;
+  HelpText = HelpText;
 
   @tracked taxRateSubject = null;
   @tracked taxEntries = [];

--- a/addon/components/search-panel-fields/search/edit.hbs
+++ b/addon/components/search-panel-fields/search/edit.hbs
@@ -1,6 +1,13 @@
-<AuLabel for={{this.inputId}}>
+<AuLabel
+  for={{this.inputId}}
+  class={{if
+    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
+    "au-u-margin-bottom-none"
+  }}
+>
   {{@field.label}}
 </AuLabel>
+<this.HelpText @field={{@field}} />
 <AuInput
   @width="block"
   class="au-u-margin-bottom-tiny"
@@ -8,8 +15,13 @@
   value={{this.value}}
   {{on "input" (perform this.search)}}
 />
-{{!-- for now this is hardcoded --}}
-<a href="/help#help-zoekresultaten" class="au-c-link" target="_blank" rel="noopener noreferrer">
-  <AuIcon @icon="info-circle" @alignment="left"/>
+{{! for now this is hardcoded }}
+<a
+  href="/help#help-zoekresultaten"
+  class="au-c-link"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <AuIcon @icon="info-circle" @alignment="left" />
   Waarom zijn mijn zoekresultaten onvolledig?
 </a>

--- a/addon/components/search-panel-fields/search/edit.js
+++ b/addon/components/search-panel-fields/search/edit.js
@@ -1,9 +1,11 @@
 import { guidFor } from '@ember/object/internals';
 import SimpleInputFieldComponent from '../../rdf-input-fields/simple-value-input-field';
+import HelpText from '@lblod/ember-submission-form-fields/components/private/help-text';
 import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class FormSearchPanelFieldsSearchEditComponent extends SimpleInputFieldComponent {
   inputId = 'search-' + guidFor(this);
+  HelpText = HelpText;
 
   search = restartableTask(async (event) => {
     await timeout(250);

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -3,7 +3,8 @@
     @icon="info-circle"
     @title="Gelieve per besluit of besluitenlijst één dossier aan te maken."
     @skin="info"
-    @size="small" />
+    @size="small"
+  />
 {{/unless}}
 <div class="au-c-form">
   <ul class="au-o-grid au-o-grid--small">
@@ -22,9 +23,15 @@
               @forceShowErrors={{@forceShowErrors}}
               @show={{@show}}
             />
-            {{#unless @show}}
-              {{! template-lint-disable no-triple-curlies}}
-              <AuHelpText>{{{field.help}}}</AuHelpText>
+
+            {{! template-lint-disable simple-unless}}
+            {{#unless
+              (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))
+            }}
+              {{#unless @show}}
+                {{! template-lint-disable no-triple-curlies}}
+                <AuHelpText>{{{field.help}}}</AuHelpText>
+              {{/unless}}
             {{/unless}}
           {{/let}}
         </li>

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -39,6 +39,11 @@
   width: 100%;
 }
 
+/* Used to override the AuFieldset gap, so the help text is positioned correctly */
+.sf-u-gap-initial {
+  gap: initial !important;
+}
+
 .currency-input {
   display: flex;
   flex-direction: row nowrap;

--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -1,4 +1,5 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
+import { getOwnConfig, macroCondition } from '@embroider/macros';
 
 // Basic fields
 import AlertComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/alert';
@@ -37,6 +38,28 @@ const CUSTOM_EDIT_COMPONENTS = new Map();
 const CUSTOM_SHOW_COMPONENTS = new Map();
 
 export function registerFormFields(customFields) {
+  if (macroCondition(!getOwnConfig().helpTextBelowLabel)) {
+    deprecate(
+      `\
+The way the help text of a form field is displayed is going to change. Fields will become responsible for displaying their help text instead of it being added below the field automatically.
+This makes the setup more flexible but it does mean custom fields need to do some manual changes.
+
+More information in the migration guide: https://github.com/lblod/ember-submission-form-fields/pull/202
+
+`,
+      false,
+      {
+        id: '@lblod/ember-submission-form-fields.help-text-position',
+        until: '3.0.0',
+        for: '@lblod/ember-submission-form-fields',
+        since: {
+          available: '2.26.0',
+          enabled: '2.26.0',
+        },
+      },
+    );
+  }
+
   registerComponentsForDisplayType(customFields, false);
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,7 +14,10 @@ const webpackConfig = {
 
 module.exports = function (defaults) {
   const customBuildConfig = {
-    // Add options here
+    // TODO: Remove this once we release v3
+    '@lblod/ember-submission-form-fields': {
+      helpTextBelowLabel: true,
+    },
     '@appuniversum/ember-appuniversum': {
       dutchDatePickerLocalization: true,
       disableWormholeElement: true,

--- a/index.js
+++ b/index.js
@@ -6,11 +6,25 @@ module.exports = {
     babel: {
       plugins: [],
     },
+    '@embroider/macros': {
+      setOwnConfig: {
+        helpTextBelowLabel: false,
+      },
+    },
   },
 
   init() {
     this._super.init.apply(this, arguments);
     this.maybeAddConcurrencyPlugin();
+  },
+
+  included: function (app) {
+    this._super.included.apply(this, arguments);
+    let addonOptions = app.options[this.name];
+    if (addonOptions) {
+      let ownConfig = this.options['@embroider/macros'].setOwnConfig;
+      Object.assign(ownConfig, addonOptions);
+    }
   },
 
   maybeAddConcurrencyPlugin() {

--- a/tests/dummy/public/test-forms/basic-fields/form.ttl
+++ b/tests/dummy/public/test-forms/basic-fields/form.ttl
@@ -72,6 +72,7 @@ ext:checkboxField a form:Field ;
     sh:order 190 ;
     sh:path ext:checkboxValue ;
     form:displayType displayTypes:checkbox ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:checkboxField .
@@ -84,7 +85,7 @@ ext:switchField a form:Field ;
     sh:order 191 ;
     sh:path ext:switchValue;
     form:displayType displayTypes:switch ;
-
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:switchField .
@@ -104,6 +105,7 @@ ext:conceptSchemeMultiSelectCheckboxesField a form:Field ;
     fieldOption:conceptScheme exampleConceptSchemes:foo-bar-baz ;
     fieldOption:orderBy qb:order ;
     form:displayType displayTypes:conceptSchemeMultiSelectCheckboxes ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg.
 
 ext:mainFg form:hasField ext:conceptSchemeMultiSelectCheckboxesField .
@@ -118,6 +120,7 @@ ext:radioButtonsField a form:Field ;
     fieldOption:conceptScheme exampleConceptSchemes:foo-bar-baz ;
     fieldOption:orderBy qb:order ;
     form:displayType displayTypes:conceptSchemeRadioButtons ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:radioButtonsField .
@@ -130,6 +133,7 @@ ext:inputField a form:Field ;
     sh:order 220 ;
     sh:path ext:inputValue ;
     form:displayType displayTypes:defaultInput ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:inputField .
@@ -142,6 +146,7 @@ ext:currencyInputField a form:Field ;
     sh:order 221 ;
     sh:path (ext:currencyInputValue eurio:value) ;
     form:displayType displayTypes:currencyInput ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:currencyInputField .
@@ -154,6 +159,7 @@ ext:numericalInputField a form:Field ;
     sh:order 222 ;
     sh:path ext:numericalInputValue;
     form:displayType displayTypes:numericalInput ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:numericalInputField .
@@ -172,6 +178,8 @@ ext:textAreaField a form:Field ;
       form:max "100" ;
       sh:resultMessage "Max. karakters overschreden." ;
       sh:path ext:textAreaValue ];
+    form:help """Some form annotation""" ;
+    # sh:description """Some description""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:textAreaField .
@@ -184,6 +192,7 @@ ext:dateField a form:Field ;
     sh:order 240 ;
     sh:path ext:dateValue ;
     form:displayType displayTypes:date ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:dateField .
@@ -195,6 +204,7 @@ ext:datePickerField a form:Field ;
     sh:name "Datepicker" ;
     sh:order 241 ;
     sh:path ext:datePickerValue ;
+    form:help """Some form annotation""" ;
     form:displayType displayTypes:datePicker ;
     sh:group ext:mainPg .
 
@@ -208,6 +218,7 @@ ext:dateTimeField a form:Field ;
     sh:order 250 ;
     sh:path ext:dateTimeValue ;
     form:displayType displayTypes:dateTime ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:dateTimeField .
@@ -220,6 +231,7 @@ ext:dateRangeField a form:Field ;
     sh:order 260 ;
     sh:path ext:dateRangeValueu ;
     form:displayType displayTypes:dateRange ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:dateRangeField .
@@ -234,6 +246,7 @@ ext:conceptSchemeSelectorField a form:Field ;
     fieldOption:conceptScheme exampleConceptSchemes:foo-bar-baz ;
     fieldOption:searchEnabled false ;
     form:displayType displayTypes:conceptSchemeSelector ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:conceptSchemeSelectorField .
@@ -248,6 +261,7 @@ ext:conceptSchemeMultiSelectorField a form:Field ;
     fieldOption:conceptScheme exampleConceptSchemes:foo-bar-baz ;
     fieldOption:searchEnabled false ;
     form:displayType displayTypes:conceptSchemeMultiSelector ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:conceptSchemeMultiSelectorField .
@@ -260,6 +274,7 @@ ext:remoteUrlsField a form:Field ;
     sh:order 310 ;
     sh:path ext:remoteUrlsValue;
     form:displayType displayTypes:remoteUrls ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:remoteUrlsField .
@@ -272,6 +287,7 @@ ext:filesField a form:Field ;
     sh:order 320 ;
     sh:path ext:filesValue ;
     form:displayType displayTypes:files ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:filesField .
@@ -290,6 +306,7 @@ ext:searchField a form:Field ;
       form:grouping form:Bag ;
       sh:resultMessage "Dit veld is verplicht." ;
       sh:path ext:searchValue ] ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 ext:mainFg form:hasField ext:searchField .
@@ -323,6 +340,7 @@ ext:vLabelOpcentiemField a form:Field ;
         sh:resultMessage "Slechts één instantie van opcentiem wordt aanvaard"@nl
     ];
     form:displayType displayTypes:vLabelOpcentiem ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg .
 
 fields:f3c1f62e-0fc6-4440-8208-7a0ef49fb28c a form:Field ;
@@ -359,6 +377,7 @@ ext:caseNumberField a form:Field ;
       ] ;
     form:options  """{"prefix" : "some-prefix-"}""" ;
     form:displayType displayTypes:caseNumber ;
+    form:help """Some form annotation""" ;
     sh:group ext:mainPg.
 
 ext:mainFg form:hasField ext:caseNumberField .


### PR DESCRIPTION
The way the help text of a form field is displayed is going to change. Fields will become responsible for displaying their help text instead of it being added below the field automatically.

This makes the setup more flexible but it does mean custom fields need to do some manual changes.

If your app doesn't use custom form fields, then no code changes are needed.

To enable the new option you can add the following configuration to your ember-cli-build.js file:
```js
    '@lblod/ember-submission-form-fields': {
      helpTextBelowLabel: true,
    },
```

After this change the help texts of the built-in form fields will be displayed below the label, instead of below the field.

**Custom field migration**
If your project uses custom fields (`registerFormFields`) then you need to make some changes if you want to support help texts (`form:help` predicates).

Your custom field component receives a `@field` argument which is an object with several properties. The `@field.help` property contains the value of the `form:help` predicate (if any), so you can check that value before rendering the help text:

```hbs

{{#if @field.help}}
  <AuHelpText>{{@field.help}}</AuHelpText>
{{/if}}
``` 

You can place the help text where it makes the most sense for your field, but it's recommended to put it below the label, to make it consistent with the built-in form fields.

