### PR TITLE
Fix an issue with Rdflib v2.2.36

### DIFF
--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
@@ -7,7 +7,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { SKOS } from '@lblod/submission-form-helpers';
-import { namedNode, Namespace } from 'rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 
 function byLabel(a, b) {
   const textA = a.label.toUpperCase();
@@ -30,7 +30,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorEditCompone
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new NamedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)

--- a/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
+++ b/addon/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
@@ -5,7 +5,7 @@ import { triplesForPath } from '@lblod/submission-form-helpers';
 import { SKOS } from '@lblod/submission-form-helpers';
 /* eslint-disable ember/no-runloop -- TODO: replace next with a different pattern */
 import { next } from '@ember/runloop';
-import { namedNode, Namespace } from 'rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 
 export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -27,7 +27,7 @@ export default class CustomSubmissionFormFieldsBestuursorgaanSelectorShowCompone
   loadOptions() {
     const metaGraph = this.args.graphs.metaGraph;
     const fieldOptions = this.args.field.options;
-    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
+    const conceptScheme = new NamedNode(fieldOptions.conceptScheme);
 
     this.options = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -7,7 +7,7 @@ import {
   SKOS,
   triplesForPath,
 } from '@lblod/submission-form-helpers';
-import { namedNode } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 import { FIELD_OPTION } from '../../utils/namespaces';
 
@@ -56,12 +56,12 @@ export default class RDFInputFieldsConceptSchemeMultiSelectCheckboxesComponent e
       if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
         return;
       }
-      conceptScheme = new namedNode(fieldOptions.conceptScheme);
+      conceptScheme = new NamedNode(fieldOptions.conceptScheme);
     }
 
     if (!orderBy) {
       if (hasValidFieldOptions(this.args.field, ['orderBy'])) {
-        orderBy = new namedNode(fieldOptions.orderBy);
+        orderBy = new NamedNode(fieldOptions.orderBy);
       }
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -8,7 +8,7 @@ import {
 } from '@lblod/submission-form-helpers';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { restartableTask, timeout } from 'ember-concurrency';
-import { Literal, namedNode } from 'rdflib';
+import { Literal, NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 import { FIELD_OPTION } from '../../utils/namespaces';
 
@@ -49,7 +49,7 @@ export default class RdfInputFieldsConceptSchemeMultiSelectorComponent extends I
         // No conceptScheme found hence this component can't work.
         return;
       }
-      conceptScheme = new namedNode(fieldOptions.conceptScheme);
+      conceptScheme = new NamedNode(fieldOptions.conceptScheme);
     }
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { SKOS } from '@lblod/submission-form-helpers';
-import { namedNode } from 'rdflib';
+import { NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 import { FIELD_OPTION } from '../../utils/namespaces';
 
@@ -22,12 +22,12 @@ export default class RdfInputFieldsConceptSchemeRadioButtonsComponent extends Si
       if (!hasValidFieldOptions(this.args.field, ['conceptScheme'])) {
         return;
       }
-      conceptScheme = new namedNode(fieldOptions.conceptScheme);
+      conceptScheme = new NamedNode(fieldOptions.conceptScheme);
     }
 
     if (!orderBy) {
       if (hasValidFieldOptions(this.args.field, ['orderBy'])) {
-        orderBy = new namedNode(fieldOptions.orderBy);
+        orderBy = new NamedNode(fieldOptions.orderBy);
       }
     }
 

--- a/addon/components/rdf-input-fields/concept-scheme-selector.js
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.js
@@ -7,7 +7,7 @@ import {
   triplesForPath,
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
-import { Literal, namedNode } from 'rdflib';
+import { Literal, NamedNode } from 'rdflib';
 import { hasValidFieldOptions } from '../../utils/has-valid-field-options';
 import { FIELD_OPTION } from '../../utils/namespaces';
 
@@ -45,7 +45,7 @@ export default class RdfInputFieldsConceptSchemeSelectorComponent extends InputF
         // No conceptScheme found hence this component can't work.
         return;
       }
-      conceptScheme = new namedNode(fieldOptions.conceptScheme);
+      conceptScheme = new NamedNode(fieldOptions.conceptScheme);
     }
 
     // SearchEnabled hasn't been found in the new spec, let's try matching it with the old spec.

--- a/addon/components/rdf-input-fields/remote-urls/edit.js
+++ b/addon/components/rdf-input-fields/remote-urls/edit.js
@@ -8,13 +8,13 @@ import {
   removeSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { RDF, NIE } from '@lblod/submission-form-helpers';
-import { namedNode, NamedNode, Namespace } from 'rdflib';
+import { NamedNode, Namespace } from 'rdflib';
 import { v4 as uuidv4 } from 'uuid';
 import { guidFor } from '@ember/object/internals';
 import { autofocus } from '../../../-private/modifiers/autofocus';
 
 const REMOTE_URI_TEMPLATE = 'http://data.lblod.info/remote-url/';
-const REQUEST_HEADER = new namedNode(
+const REQUEST_HEADER = new NamedNode(
   'http://data.lblod.info/request-headers/29b14d06-e584-45d6-828a-ce1f0c018a8e',
 );
 
@@ -189,7 +189,7 @@ export default class FormInputFieldsRemoteUrlsEditComponent extends InputFieldCo
     const uuid = uuidv4();
     const remoteUrl = new RemoteUrl({
       uuid,
-      uri: new namedNode(REMOTE_URI_TEMPLATE + `${uuid}`),
+      uri: new NamedNode(REMOTE_URI_TEMPLATE + `${uuid}`),
       address: '',
       errors: [],
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -26456,11 +26456,11 @@
       }
     },
     "node_modules/rdflib": {
-      "version": "2.2.35",
-      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.35.tgz",
-      "integrity": "sha512-PudSzYz0cVy5iuKmxaNfl0WPuPq4h9LAWbyJSn36gwTMtWbBgcqUDobdcDK3P6mxeOui/cosDXu0A9oVicVfyA==",
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.36.tgz",
+      "integrity": "sha512-dZ4Xvjm2nqKq3tfiL65veKxLi6DqQTawQE3iz/aO7VqnmXzwQH4ugrsJZ3sn2kRLLax/TX3/TgYoAWocTYLwMg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.24.4",
         "@frogcat/ttl2jsonld": "^0.0.9",
         "@xmldom/xmldom": "^0.8.10",
         "cross-fetch": "^3.1.8",


### PR DESCRIPTION
We were using the `namedNode` util as a constructor, which doesn't work anymore in the latest release (and only worked by accident before).

This should also fix CI for #202 