### PR TITLE
Remove unneeded app exports

### DIFF
--- a/addon/-private/helpers/component-for-display-type.js
+++ b/addon/-private/helpers/component-for-display-type.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { getComponentForDisplayType } from '@lblod/ember-submission-form-fields/utils/display-type';
+import { getComponentForDisplayType } from '../../utils/display-type';
 
 export default helper(function componentForDisplayType(
   [displayType],

--- a/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
+++ b/addon/components/custom-submission-form-fields/remote-urls/edit.hbs
@@ -1,4 +1,4 @@
-<RdfInputFields::RemoteUrls::Edit
+<this.RemoteUrlsEdit
   @field={{@field}}
   @form={{@form}}
   @formStore={{@formStore}}

--- a/addon/components/custom-submission-form-fields/remote-urls/edit.js
+++ b/addon/components/custom-submission-form-fields/remote-urls/edit.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import RemoteUrlsEdit from '../../rdf-input-fields/remote-urls/edit';
+
+export default class CustomSubmissionFormFieldsRemoteUrls extends Component {
+  RemoteUrlsEdit = RemoteUrlsEdit;
+}

--- a/addon/components/form-section.hbs
+++ b/addon/components/form-section.hbs
@@ -25,18 +25,20 @@
     {{#each this.children as |field|}}
       {{#if field.displayType}}
         {{#if (this.childIsSection field)}}
-          <FormSection
-            @level={{this.nextLevel}}
-            @form={{@form}}
-            @section={{field}}
-            @formStore={{@formStore}}
-            @graphs={{@graphs}}
-            @sourceNode={{@sourceNode}}
-            @forceShowErrors={{@forceShowErrors}}
-            @cacheConditionals={{@cacheConditionals}}
-            @show={{@show}}
-            @useNewListingLayout={{@useNewListingLayout}}
-          />
+          {{#let this as |FormSection|}}
+            <FormSection
+              @level={{this.nextLevel}}
+              @form={{@form}}
+              @section={{field}}
+              @formStore={{@formStore}}
+              @graphs={{@graphs}}
+              @sourceNode={{@sourceNode}}
+              @forceShowErrors={{@forceShowErrors}}
+              @cacheConditionals={{@cacheConditionals}}
+              @show={{@show}}
+              @useNewListingLayout={{@useNewListingLayout}}
+            />
+          {{/let}}
           {{#if @last}}
             {{#if (not (this.isLast this.children field))}}
               <AuHr @size="large" />
@@ -45,7 +47,7 @@
             <AuHr @size="large" />
           {{/if}}
         {{else if (this.childIsListing field)}}
-          <Listing
+          <this.Listing
             @level={{this.nextLevel}}
             @listing={{field}}
             @formStore={{@formStore}}
@@ -59,7 +61,7 @@
         {{else}}
           <div class="au-u-margin-bottom-small">
             {{#let
-              (component-for-display-type field.displayType show=@show)
+              (this.componentForDisplayType field.displayType show=@show)
               as |FormField|
             }}
               <FormField
@@ -75,7 +77,9 @@
             {{/let}}
 
             {{! template-lint-disable simple-unless}}
-            {{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
+            {{#unless
+              (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))
+            }}
               {{#if field.help}}
                 {{! template-lint-disable no-triple-curlies}}
                 <AuHelpText>{{{field.help}}}</AuHelpText>

--- a/addon/components/form-section.js
+++ b/addon/components/form-section.js
@@ -13,6 +13,8 @@ import {
 } from '../models/section';
 import { LISTING_TYPE } from '../models/listing';
 import { helper } from '@ember/component/helper';
+import componentForDisplayType from '../-private/helpers/component-for-display-type';
+import Listing from './listing';
 
 const childIsSection = helper(function ([child]) {
   return (
@@ -31,6 +33,8 @@ export default class SubmissionFormSectionComponent extends Component {
   @tracked children = A();
   @tracked validations = [];
   isLast = isLast;
+  componentForDisplayType = componentForDisplayType;
+  Listing = Listing;
 
   observerLabel = `section-${guidFor(this)}`;
 

--- a/addon/components/listing/list.hbs
+++ b/addon/components/listing/list.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-flow" ...attributes>
     {{#each @subForms as |subForm index|}}
       {{#let (eq index 0) (this.isLast @subForms subForm) as |isFirst isLast|}}
-        <SubForm
+        <this.SubForm
           @subForm={{subForm}}
           @formStore={{@formStore}}
           @graphs={{@graphs}}
@@ -44,7 +44,7 @@
           (eq index 0) (this.isLast @subForms subForm)
           as |isFirst isLast|
         }}
-          <SubForm
+          <this.SubForm
             @subForm={{subForm}}
             @formStore={{@formStore}}
             @graphs={{@graphs}}

--- a/addon/components/listing/list.js
+++ b/addon/components/listing/list.js
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
+import SubForm from '../sub-form';
 
 export default class List extends Component {
   isLast = isLast;
+  SubForm = SubForm;
 }

--- a/addon/components/listing/table/row.hbs
+++ b/addon/components/listing/table/row.hbs
@@ -16,7 +16,7 @@
   {{/if}}
   {{#each this.fields as |field|}}
     {{#let
-      (component-for-display-type field.displayType show=@show)
+      (this.componentForDisplayType field.displayType show=@show)
       as |FormField|
     }}
       <td>

--- a/addon/components/listing/table/row.js
+++ b/addon/components/listing/table/row.js
@@ -4,8 +4,10 @@ import {
   getTopLevelSections,
 } from '@lblod/ember-submission-form-fields/utils/model-factory';
 import OrderButtonGroup from '@lblod/ember-submission-form-fields/components/listing/order-button-group';
+import componentForDisplayType from '../../../-private/helpers/component-for-display-type';
 
 export default class ListingTableRow extends Component {
+  componentForDisplayType = componentForDisplayType;
   OrderButtonGroup = OrderButtonGroup;
 
   constructor() {

--- a/addon/components/rdf-form.hbs
+++ b/addon/components/rdf-form.hbs
@@ -1,6 +1,6 @@
 <div class="au-o-grid au-o-grid--small" ...attributes>
   {{#each this.sections as |section|}}
-    <FormSection
+    <this.FormSection
       class={{@groupClass}}
       @form={{@form}}
       @section={{section}}

--- a/addon/components/rdf-form.js
+++ b/addon/components/rdf-form.js
@@ -6,10 +6,12 @@ import {
 } from '@lblod/submission-form-helpers';
 import { getRootNodeForm, getTopLevelSections } from '../utils/model-factory';
 import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
+import FormSection from './form-section';
 
 export default class RdfForm extends Component {
   sections = []; // NOTE don't think this needs to be an ember array as it will never change
   isLast = isLast;
+  FormSection = FormSection;
 
   constructor() {
     super(...arguments);

--- a/addon/components/sub-form.hbs
+++ b/addon/components/sub-form.hbs
@@ -36,7 +36,7 @@
 
     <div class="au-o-flow">
       {{#each this.sections as |section|}}
-        <FormSection
+        <this.FormSection
           @form={{@subForm.uri}}
           @section={{section}}
           @formStore={{@formStore}}
@@ -76,7 +76,7 @@
   <div class="au-o-grid">
     <div class="au-o-flow au-o-grid__item au-u-4-5">
       {{#each this.sections as |section|}}
-        <FormSection
+        <this.FormSection
           @form={{@subForm.uri}}
           @section={{section}}
           @formStore={{@formStore}}

--- a/addon/components/sub-form.js
+++ b/addon/components/sub-form.js
@@ -2,11 +2,13 @@ import Component from '@glimmer/component';
 import { getTopLevelSections } from '../utils/model-factory';
 import isLast from '@lblod/ember-submission-form-fields/-private/helpers/is-last';
 import OrderButtonGroup from '@lblod/ember-submission-form-fields/components/listing/order-button-group';
+import FormSection from './form-section';
 
 export default class SubFormComponent extends Component {
   sections = []; // NOTE don't think this needs to be an ember array as it will never change
   isLast = isLast;
   OrderButtonGroup = OrderButtonGroup;
+  FormSection = FormSection;
 
   constructor() {
     super(...arguments);

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -12,7 +12,7 @@
       {{#if field.displayType}}
         <li class="au-o-grid__item au-u-1-1">
           {{#let
-            (component-for-display-type field.displayType show=@show)
+            (this.componentForDisplayType field.displayType show=@show)
             as |FormField|
           }}
             <FormField

--- a/addon/components/submission-form.js
+++ b/addon/components/submission-form.js
@@ -6,9 +6,11 @@ import { A } from '@ember/array';
 import { guidFor } from '@ember/object/internals';
 /* eslint-disable ember/no-runloop -- TODO: replace next with a different pattern */
 import { next } from '@ember/runloop';
+import componentForDisplayType from '../-private/helpers/component-for-display-type';
 
 export default class SubmissionFormComponent extends Component {
   @tracked fields = A();
+  componentForDisplayType = componentForDisplayType;
 
   observerLabel = `form-root-${guidFor(this)}`;
 

--- a/app/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
+++ b/app/components/custom-submission-form-fields/bestuursorgaan-selector/edit.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/edit';

--- a/app/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
+++ b/app/components/custom-submission-form-fields/bestuursorgaan-selector/show.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/bestuursorgaan-selector/show';

--- a/app/components/custom-submission-form-fields/remote-urls/edit.js
+++ b/app/components/custom-submission-form-fields/remote-urls/edit.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/custom-submission-form-fields/remote-urls/edit';

--- a/app/components/form-section.js
+++ b/app/components/form-section.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/form-section';

--- a/app/components/listing.js
+++ b/app/components/listing.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/listing';

--- a/app/components/property-group.js
+++ b/app/components/property-group.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/property-group';

--- a/app/components/rdf-input-fields/case-number.js
+++ b/app/components/rdf-input-fields/case-number.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/case-number';

--- a/app/components/rdf-input-fields/checkbox.js
+++ b/app/components/rdf-input-fields/checkbox.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/checkbox';

--- a/app/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
+++ b/app/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-multi-select-checkboxes';

--- a/app/components/rdf-input-fields/concept-scheme-multi-selector.js
+++ b/app/components/rdf-input-fields/concept-scheme-multi-selector.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-multi-selector';

--- a/app/components/rdf-input-fields/concept-scheme-radio-buttons.js
+++ b/app/components/rdf-input-fields/concept-scheme-radio-buttons.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-radio-buttons';

--- a/app/components/rdf-input-fields/concept-scheme-selector.js
+++ b/app/components/rdf-input-fields/concept-scheme-selector.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/concept-scheme-selector';

--- a/app/components/rdf-input-fields/date-range.js
+++ b/app/components/rdf-input-fields/date-range.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-range';

--- a/app/components/rdf-input-fields/date-time.js
+++ b/app/components/rdf-input-fields/date-time.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date-time';

--- a/app/components/rdf-input-fields/date.js
+++ b/app/components/rdf-input-fields/date.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/date';

--- a/app/components/rdf-input-fields/files.js
+++ b/app/components/rdf-input-fields/files.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/files';

--- a/app/components/rdf-input-fields/heading.js
+++ b/app/components/rdf-input-fields/heading.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/heading';

--- a/app/components/rdf-input-fields/input-field.js
+++ b/app/components/rdf-input-fields/input-field.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';

--- a/app/components/rdf-input-fields/input.js
+++ b/app/components/rdf-input-fields/input.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input';

--- a/app/components/rdf-input-fields/numerical-input.js
+++ b/app/components/rdf-input-fields/numerical-input.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/numerical-input';

--- a/app/components/rdf-input-fields/remote-urls/edit.js
+++ b/app/components/rdf-input-fields/remote-urls/edit.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/remote-urls/edit';

--- a/app/components/rdf-input-fields/remote-urls/show.js
+++ b/app/components/rdf-input-fields/remote-urls/show.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/remote-urls/show';

--- a/app/components/rdf-input-fields/search.js
+++ b/app/components/rdf-input-fields/search.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/search';

--- a/app/components/rdf-input-fields/simple-value-input-field.js
+++ b/app/components/rdf-input-fields/simple-value-input-field.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';

--- a/app/components/rdf-input-fields/switch.js
+++ b/app/components/rdf-input-fields/switch.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/switch';

--- a/app/components/rdf-input-fields/text-area.js
+++ b/app/components/rdf-input-fields/text-area.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/text-area';

--- a/app/components/rdf-input-fields/vlabel-opcentiem.js
+++ b/app/components/rdf-input-fields/vlabel-opcentiem.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/rdf-input-fields/vlabel-opcentiem';

--- a/app/components/search-panel-fields/search/edit.js
+++ b/app/components/search-panel-fields/search/edit.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/edit';

--- a/app/components/search-panel-fields/search/show.js
+++ b/app/components/search-panel-fields/search/show.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/search-panel-fields/search/show';

--- a/app/components/sub-form.js
+++ b/app/components/sub-form.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/components/sub-form';

--- a/app/helpers/component-for-display-type.js
+++ b/app/helpers/component-for-display-type.js
@@ -1,1 +1,0 @@
-export { default } from '@lblod/ember-submission-form-fields/helpers/component-for-display-type';


### PR DESCRIPTION
These things were never intended to be used publically, since everything is handled by the `<RdfForm>` component. This change makes that explicit and will make the future .gjs conversion easier.