### PR TITLE
Reexport the FormSection component

### DIFF
--- a/addon/components/form-section.hbs
+++ b/addon/components/form-section.hbs
@@ -25,20 +25,19 @@
     {{#each this.children as |field|}}
       {{#if field.displayType}}
         {{#if (this.childIsSection field)}}
-          {{#let this as |FormSection|}}
-            <FormSection
-              @level={{this.nextLevel}}
-              @form={{@form}}
-              @section={{field}}
-              @formStore={{@formStore}}
-              @graphs={{@graphs}}
-              @sourceNode={{@sourceNode}}
-              @forceShowErrors={{@forceShowErrors}}
-              @cacheConditionals={{@cacheConditionals}}
-              @show={{@show}}
-              @useNewListingLayout={{@useNewListingLayout}}
-            />
-          {{/let}}
+          {{! TODO: find a way to recursively invoke a component in strict mode so we can remove the app export }}
+          <Private::FormSection
+            @level={{this.nextLevel}}
+            @form={{@form}}
+            @section={{field}}
+            @formStore={{@formStore}}
+            @graphs={{@graphs}}
+            @sourceNode={{@sourceNode}}
+            @forceShowErrors={{@forceShowErrors}}
+            @cacheConditionals={{@cacheConditionals}}
+            @show={{@show}}
+            @useNewListingLayout={{@useNewListingLayout}}
+          />
           {{#if @last}}
             {{#if (not (this.isLast this.children field))}}
               <AuHr @size="large" />

--- a/app/components/private/form-section.js
+++ b/app/components/private/form-section.js
@@ -1,0 +1,2 @@
+// TODO: find a way to recursively invoke a component in strict mode so we can remove the app export
+export { default } from '@lblod/ember-submission-form-fields/components/form-section';


### PR DESCRIPTION
It seems the way I [converted](https://github.com/lblod/ember-submission-form-fields/pull/204/files#diff-32973fd12e76fc77cb8ec0e9f7ed02a4d558eb673ca2e40959518527fe77854a) the recursive component invocation doesn't actually work and threw a runtime error.

We temporarily reexport the FormSection component as `<Private::FormSection>` so the recursion works again, without it being available as a "public" component.