### PR TITLE
[DL-6466] Don't trim the search field values

### DIFF
--- a/addon/components/rdf-input-fields/search.js
+++ b/addon/components/rdf-input-fields/search.js
@@ -9,6 +9,6 @@ export default class RdfInputFieldsSearchComponent extends SimpleInputFieldCompo
 
   search = restartableTask(async (event) => {
     await timeout(250);
-    this.updateValue(event.target.value.trim());
+    this.updateValue(event.target.value);
   });
 }

--- a/addon/components/search-panel-fields/search/edit.js
+++ b/addon/components/search-panel-fields/search/edit.js
@@ -9,7 +9,7 @@ export default class FormSearchPanelFieldsSearchEditComponent extends SimpleInpu
 
   search = restartableTask(async (event) => {
     await timeout(250);
-    this.value = event.target.value.trim();
+    this.value = event.target.value;
     this.updateValue(this.value);
   });
 }


### PR DESCRIPTION
This prevented users from typing a space in their search queries. The consuming side is now responsible for trimming the search value (if needed).

It seems this has been an issue since the component was originally created, but the issue was never reported until now.