### PR TITLE
Drop support for old dependencies

### DIFF
--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -111,7 +111,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
         'filter[:uri:]': uri.value,
         page: { size: 1 },
       });
-      const file = files.slice()[0]; // TODO: remove .slice once we support only Ember Data 4.8+
+      const file = files[0];
       if (file) return new FileField({ record: file, errors: [] });
       else
         return new FileField({

--- a/addon/components/rdf-input-fields/remote-urls/show.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/show.hbs
@@ -63,14 +63,5 @@
     {{/if}}
   {{/if}}
 {{else}}
-  {{! TODO: Remove this check once we drop Appuniversum v2 support }}
-  {{#if
-    (macroCondition
-      (macroDependencySatisfies "@appuniversum/ember-appuniversum" "^3.2.0")
-    )
-  }}
-    <AuLoader @centered={{false}} @hideMessage={{true}}>Links aan het laden</AuLoader>
-  {{else}}
-    <AuLoader @padding="small" />
-  {{/if}}
+  <AuLoader @centered={{false}} @hideMessage={{true}}>Links aan het laden</AuLoader>
 {{/if}}

--- a/addon/components/rdf-input-fields/remote-urls/show.js
+++ b/addon/components/rdf-input-fields/remote-urls/show.js
@@ -84,7 +84,7 @@ export default class FormInputFieldsRemoteUrlsShowComponent extends Component {
       page: { size: 1 },
     });
     if (remoteUrls.length) {
-      return remoteUrls.slice()[0]; // TODO: remove .slice once we support only Ember Data 4.8+
+      return remoteUrls[0];
     } else {
       throw `No remote-url could be found for ${remoteObjectUri}`;
     }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -36,16 +36,6 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  // The built-in compat adapters for Ember Data shouldn't be needed anymore.
-  // This code can be removed once https://github.com/embroider-build/embroider/pull/1369 is released.
-  const compatAdapters = new Map();
-  compatAdapters.set('ember-data', null);
-  compatAdapters.set('@ember-data/adapter', null);
-  compatAdapters.set('@ember-data/model', null);
-  compatAdapters.set('@ember-data/record-data', null);
-  compatAdapters.set('@ember-data/serializer', null);
-  compatAdapters.set('@ember-data/store', null);
-
   const { maybeEmbroider } = require('@embroider/test-setup');
   return maybeEmbroider(app, {
     skipBabel: [
@@ -53,23 +43,6 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
-    packageRules: [
-      {
-        package: '@ember-data/store',
-        addonModules: {
-          '-private.js': {
-            dependsOnModules: [],
-          },
-          '-private/system/core-store.js': {
-            dependsOnModules: [],
-          },
-          '-private/system/model/internal-model.js': {
-            dependsOnModules: [],
-          },
-        },
-      },
-    ],
-    compatAdapters,
     packagerOptions: {
       webpackConfig,
     },

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ module.exports = {
   name: require('./package').name,
   options: {
     babel: {
-      plugins: [],
+      plugins: [
+        require.resolve('ember-concurrency/async-arrow-task-transform'),
+      ],
     },
     '@embroider/macros': {
       setOwnConfig: {
@@ -13,30 +15,12 @@ module.exports = {
     },
   },
 
-  init() {
-    this._super.init.apply(this, arguments);
-    this.maybeAddConcurrencyPlugin();
-  },
-
   included: function (app) {
     this._super.included.apply(this, arguments);
     let addonOptions = app.options[this.name];
     if (addonOptions) {
       let ownConfig = this.options['@embroider/macros'].setOwnConfig;
       Object.assign(ownConfig, addonOptions);
-    }
-  },
-
-  maybeAddConcurrencyPlugin() {
-    const VersionChecker = require('ember-cli-version-checker');
-    const checker = new VersionChecker(this.project);
-    const dep = checker.for('ember-concurrency');
-
-    if (dep.gte('4.0.0')) {
-      // ember-concurrency v4+ requires a custom babel transform. Once we drop ember-concurrency v3 support we can remove this conditional registration.
-      this.options.babel.plugins.push(
-        require.resolve('ember-concurrency/async-arrow-task-transform'),
-      );
     }
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ember-cli-version-checker": "^5.1.2",
         "ember-concurrency": "^4.0.2",
         "ember-modifier": "^4.1.0",
-        "ember-truth-helpers": "^3.0.0 || ^4.0.0",
+        "ember-truth-helpers": "^4.0.0",
         "forking-store": "^2.0.0",
         "rdflib": "^2.2.19",
         "uuid": "^9.0.0"
@@ -7935,7 +7935,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
       "integrity": "sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==",
-      "dev": true,
       "dependencies": {
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^2.0.0",
@@ -7960,7 +7959,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -7972,7 +7970,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
       "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
       "dependencies": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
@@ -7996,7 +7993,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
       "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
       "dependencies": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -8008,7 +8004,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8017,7 +8012,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
       "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
         "matcher-collection": "^1.0.0"
@@ -8027,7 +8021,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
       "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
       "dependencies": {
         "async-disk-cache": "^1.2.1",
         "async-promise-queue": "^1.0.3",
@@ -8052,7 +8045,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
       "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
       "dependencies": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -8064,7 +8056,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
       "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -8080,7 +8071,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
       "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
-      "dev": true,
       "dependencies": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -8095,7 +8085,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -8109,7 +8098,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -8117,14 +8105,12 @@
     "node_modules/broccoli-stew/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/broccoli-stew/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -8133,7 +8119,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -8147,7 +8132,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -8156,7 +8140,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8165,7 +8148,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
       "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
       "dependencies": {
         "minimatch": "^3.0.2"
       }
@@ -8174,7 +8156,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -8185,14 +8166,12 @@
     "node_modules/broccoli-stew/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/broccoli-stew/node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -8201,7 +8180,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -8213,7 +8191,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
       "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
       "dependencies": {
         "debug": "^2.1.3",
         "heimdalljs": "^0.2.3",
@@ -8226,7 +8203,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8235,7 +8211,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8244,7 +8219,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
       "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -11046,19 +11020,6 @@
         "@glimmer/component": "^1.1.2 || ^2.0.0",
         "@glimmer/tracking": "^1.1.2",
         "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
-      }
-    },
-    "node_modules/ember-basic-dropdown/node_modules/ember-truth-helpers": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.3.tgz",
-      "integrity": "sha512-T6Ogd3pk9FxYiZfSxdjgn3Hb3Ksqgw7CD23V9qfig9jktNdkNEHo4+3PA3cSD/+3a2kdH3KmNvKyarVuzdtEkA==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.8.6",
-        "ember-functions-as-helper-polyfill": "^2.1.2"
-      },
-      "peerDependencies": {
-        "ember-source": ">=3.28.0"
       }
     },
     "node_modules/ember-cache-primitive-polyfill": {
@@ -14475,7 +14436,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-functions-as-helper-polyfill/-/ember-functions-as-helper-polyfill-2.1.2.tgz",
       "integrity": "sha512-yvW6xykvZEIYzzwlrC/g9yu6LtLkkj5F+ho6U+BDxN1uREMgoMOZnji7sSILn5ITVpaJ055DPcO+utEFD7IZOA==",
-      "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.11",
         "ember-cli-typescript": "^5.0.0",
@@ -14493,7 +14453,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
       "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -14511,7 +14470,6 @@
       "version": "7.12.18",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
       "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -14520,7 +14478,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
       "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -14529,7 +14486,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
       "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dev": true,
       "dependencies": {
         "find-babel-config": "^1.1.0",
         "glob": "^7.1.2",
@@ -14545,7 +14501,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
       "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dev": true,
       "dependencies": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
@@ -14569,7 +14524,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -14578,7 +14532,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
       "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
       "dependencies": {
         "minimatch": "^3.0.2"
       }
@@ -14587,7 +14540,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
       "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-      "dev": true,
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
         "matcher-collection": "^1.0.0"
@@ -14597,7 +14549,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
       "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -14606,7 +14557,6 @@
       "version": "7.26.11",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
       "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.0",
         "@babel/helper-compilation-targets": "^7.12.0",
@@ -14647,7 +14597,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
       "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dev": true,
       "dependencies": {
         "resolve-package-path": "^2.0.0",
         "semver": "^6.3.0",
@@ -14661,7 +14610,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
       "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dev": true,
       "dependencies": {
         "path-root": "^0.1.1",
         "resolve": "^1.13.1"
@@ -14674,7 +14622,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -14684,7 +14631,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -14699,7 +14645,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -14708,7 +14653,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.3.0.tgz",
       "integrity": "sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==",
-      "dev": true,
       "dependencies": {
         "ansi-to-html": "^0.6.15",
         "broccoli-stew": "^3.0.0",
@@ -14729,7 +14673,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -14752,7 +14695,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^2.0.0"
       },
@@ -14764,7 +14706,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
       "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
-      "dev": true,
       "dependencies": {
         "@types/fs-extra": "^5.0.5",
         "@types/minimatch": "^3.0.3",
@@ -14780,7 +14721,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
       "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
-      "dev": true,
       "dependencies": {
         "fixturify": "^1.2.0",
         "tmp": "^0.0.33"
@@ -14790,7 +14730,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -14804,7 +14743,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14819,7 +14757,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
       "engines": {
         "node": ">=8.12.0"
       }
@@ -14828,7 +14765,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -14837,7 +14773,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
@@ -14850,7 +14785,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -14861,14 +14795,12 @@
     "node_modules/ember-functions-as-helper-polyfill/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/ember-functions-as-helper-polyfill/node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
       "dependencies": {
         "p-try": "^1.0.0"
       },
@@ -14880,7 +14812,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^1.1.0"
       },
@@ -14892,7 +14823,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dev": true,
       "dependencies": {
         "find-up": "^2.1.0"
       },
@@ -14903,20 +14833,17 @@
     "node_modules/ember-functions-as-helper-polyfill/node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/ember-functions-as-helper-polyfill/node_modules/reselect": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA==",
-      "dev": true
+      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA=="
     },
     "node_modules/ember-functions-as-helper-polyfill/node_modules/resolve-package-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
       "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
       "dependencies": {
         "path-root": "^0.1.1",
         "resolve": "^1.17.0"
@@ -14929,7 +14856,6 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -14938,7 +14864,6 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14950,7 +14875,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -14959,7 +14883,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -16278,19 +16201,6 @@
         "ember-basic-dropdown": "^8.2.0",
         "ember-concurrency": "^4.0.2",
         "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
-      }
-    },
-    "node_modules/ember-power-select/node_modules/ember-truth-helpers": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.3.tgz",
-      "integrity": "sha512-T6Ogd3pk9FxYiZfSxdjgn3Hb3Ksqgw7CD23V9qfig9jktNdkNEHo4+3PA3cSD/+3a2kdH3KmNvKyarVuzdtEkA==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/addon-shim": "^1.8.6",
-        "ember-functions-as-helper-polyfill": "^2.1.2"
-      },
-      "peerDependencies": {
-        "ember-source": ">=3.28.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -18268,337 +18178,16 @@
       }
     },
     "node_modules/ember-truth-helpers": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.1.1.tgz",
-      "integrity": "sha512-FHwJAx77aA5q27EhdaaiBFuy9No+8yaWNT5A7zs0sIFCmf14GbcLn69vJEp6mW7vkITezizGAWhw7gL0Wbk7DA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-4.0.3.tgz",
+      "integrity": "sha512-T6Ogd3pk9FxYiZfSxdjgn3Hb3Ksqgw7CD23V9qfig9jktNdkNEHo4+3PA3cSD/+3a2kdH3KmNvKyarVuzdtEkA==",
+      "license": "MIT",
       "dependencies": {
-        "ember-cli-babel": "^7.22.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "@embroider/addon-shim": "^1.8.6",
+        "ember-functions-as-helper-polyfill": "^2.1.2"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/@babel/runtime": {
-      "version": "7.12.18",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/babel-plugin-module-resolver": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-      "integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-      "dependencies": {
-        "find-babel-config": "^1.1.0",
-        "glob": "^7.1.2",
-        "pkg-up": "^2.0.0",
-        "reselect": "^3.0.1",
-        "resolve": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/broccoli-source": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-2.1.2.tgz",
-      "integrity": "sha512-1lLayO4wfS0c0Sj50VfHJXNWf94FYY0WUhxj0R77thbs6uWI7USiOWFqQV5dRmhAJnoKaGN4WyLGQbgjgiYFwQ==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ember-cli-babel": {
-      "version": "7.26.11",
-      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz",
-      "integrity": "sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==",
-      "dependencies": {
-        "@babel/core": "^7.12.0",
-        "@babel/helper-compilation-targets": "^7.12.0",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-decorators": "^7.13.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-runtime": "^7.13.9",
-        "@babel/plugin-transform-typescript": "^7.13.0",
-        "@babel/polyfill": "^7.11.5",
-        "@babel/preset-env": "^7.16.5",
-        "@babel/runtime": "7.12.18",
-        "amd-name-resolver": "^1.3.1",
-        "babel-plugin-debug-macros": "^0.3.4",
-        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
-        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
-        "babel-plugin-module-resolver": "^3.2.0",
-        "broccoli-babel-transpiler": "^7.8.0",
-        "broccoli-debug": "^0.6.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-source": "^2.1.2",
-        "calculate-cache-key-for-tree": "^2.0.0",
-        "clone": "^2.1.2",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^4.1.0",
-        "ensure-posix-path": "^1.0.2",
-        "fixturify-project": "^1.10.0",
-        "resolve-package-path": "^3.1.0",
-        "rimraf": "^3.0.1",
-        "semver": "^5.5.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ember-cli-babel/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ember-cli-babel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ember-cli-version-checker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
-      "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
-      "dependencies": {
-        "resolve-package-path": "^2.0.0",
-        "semver": "^6.3.0",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
-      "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.13.1"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/fixturify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-1.3.0.tgz",
-      "integrity": "sha512-tL0svlOy56pIMMUQ4bU1xRe6NZbFSa/ABTWMxW2mH38lFGc9TrNAKWcMBQ7eIjo3wqSS8f2ICabFaatFyFmrVQ==",
-      "dependencies": {
-        "@types/fs-extra": "^5.0.5",
-        "@types/minimatch": "^3.0.3",
-        "@types/rimraf": "^2.0.2",
-        "fs-extra": "^7.0.1",
-        "matcher-collection": "^2.0.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/fixturify-project": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fixturify-project/-/fixturify-project-1.10.0.tgz",
-      "integrity": "sha512-L1k9uiBQuN0Yr8tA9Noy2VSQ0dfg0B8qMdvT7Wb5WQKc7f3dn3bzCbSrqlb+etLW+KDV4cBC7R1OvcMg3kcxmA==",
-      "dependencies": {
-        "fixturify": "^1.2.0",
-        "tmp": "^0.0.33"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/ember-truth-helpers/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha512-fjAPuiws93rm7mPUu21RdBnkeZNrbfCFCwfAhPWY+rR3zG0ubpe5cEReHOw5fIbfmsxEV/g2kSxGTATY3Bpnwg==",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
-    "node_modules/ember-truth-helpers/node_modules/reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha512-b/6tFZCmRhtBMa4xGqiiRp9jh9Aqi2A687Lo265cN0/QohJQEBPiQ52f4QB6i0eF3yp3hmLL21LSGBcML2dlxA=="
-    },
-    "node_modules/ember-truth-helpers/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-truth-helpers/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "engines": {
-        "node": ">= 4.0.0"
+        "ember-source": ">=3.28.0"
       }
     },
     "node_modules/ember-try": {
@@ -24892,7 +24481,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "ember-concurrency": "^2.3.2 || ^3.0.0 || ^4.0.2",
+        "ember-concurrency": "^4.0.2",
         "ember-modifier": "^4.1.0",
         "ember-truth-helpers": "^3.0.0 || ^4.0.0",
         "forking-store": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",
-        "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
+        "ember-data": "^5.0.0",
         "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "ember-source": ">= 4.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.15.0 || ^3.7.0",
+        "@appuniversum/ember-appuniversum": "^3.7.0",
         "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
         "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "ember-source": ">= 4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "ember-cli-sass": "^10.0.1",
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
-        "ember-data": "~5.3.0",
+        "ember-data": "~5.3.13",
         "ember-load-initializers": "^2.1.2",
         "ember-mu-transform-helpers": "^2.1.2",
         "ember-page-title": "^8.2.3",
@@ -1773,104 +1773,115 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-5.3.9.tgz",
-      "integrity": "sha512-qa8wrmh0iHdVeDcO+smgLkuic4ZwKN8QuCNKcbaK4Y3lRkF86IKpeJFBBNkDlZ7Bmxlir2TN9oIUp6I0Cx3osA==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-5.3.13.tgz",
+      "integrity": "sha512-tXx8XftDEAH/biUPZuWm73x6wPyXDlCf+k3IlgLVoGtY4MtqmX3e44JadhzrflqVcs38Ic2oosWZORP7UJ5wPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "1.2.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7",
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/legacy-compat": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/legacy-compat": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember-data/debug": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-5.3.9.tgz",
-      "integrity": "sha512-yB9V1JRzEKAoeR0G6JS0Tc6rQUNTL/qDXk6mc5nNRCHyoZ6u35/TuVXm62zzwBsDwU+kNJcCrbcUW11/TIw3Ng==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-5.3.13.tgz",
+      "integrity": "sha512-O8YH65JdrDbGNtaUs8ql/0YZkIVhMsbaDHab4x0SuwfeoqlMtuK6Ym6LosMv/36vzTtIUQh9xJ+td4rcSoErWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/model": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/model": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember-data/graph": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/graph/-/graph-5.3.9.tgz",
-      "integrity": "sha512-mbwt7dDta7maKTsquBXpcU8hDf0Ukq9mtQNd2CPhkFgQ9YBt28NumBuiAviMr4HloOcJ8WA/GtX/RXIGP6yvEw==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/graph/-/graph-5.3.13.tgz",
+      "integrity": "sha512-NMt1nP7dMVf/tzxamyQi59DaRHZF6F8aSuJmoC4zOcuGqE6QPURpcoIwbo3RM+R4e+4kVKHmp40kcNA0Bfu4zQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/store": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/store": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember-data/json-api": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/json-api/-/json-api-5.3.9.tgz",
-      "integrity": "sha512-q+x+EFAKLT0WmrDe+7J1Yx9bn/KUDLU/QwJ2Vapnve05qXOOyXgjMF6ckSXBaulDIZksGGgTegNRzPHLB4o1fg==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/json-api/-/json-api-5.3.13.tgz",
+      "integrity": "sha512-pD4rKQ1weGb0e8g5hjqMxbbaoSJrdYvxHt4Qu38v/5321qdAMwZQ503m6FDhUe+S39MaYA/qIel/wbiuRWzbFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3",
+        "fuse.js": "7.1.0",
+        "json-to-ast": "2.1.0"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/graph": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/graph": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@warp-drive/core-types": "0.0.3"
       }
     },
     "node_modules/@ember-data/legacy-compat": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/legacy-compat/-/legacy-compat-5.3.9.tgz",
-      "integrity": "sha512-PGh9t+1DOwPQFJuWxuBlVFRxT7Q63pzoEvC0HXKVfL6pgvEZYPNQ6WNJ3H4MkD+zcdd6rWpCwjsdMq/VQRWfAQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/legacy-compat/-/legacy-compat-5.3.13.tgz",
+      "integrity": "sha512-NMnC43VlQ8x+i1uwCcf/oQiEiZ9DDxVZ3/NJWoviN+ajg6UHtCk8N3HryhDbxTxytVjSrUpO9Igq69TjN7XNqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/graph": "5.3.9",
-        "@ember-data/json-api": "5.3.9",
-        "@ember-data/request": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@ember/test-waiters": "^3.1.0",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/graph": "5.3.13",
+        "@ember-data/json-api": "5.3.13",
+        "@ember-data/request": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@ember/test-waiters": "^3.1.0 || >= 4.0.0",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "@ember-data/graph": {
@@ -1882,29 +1893,31 @@
       }
     },
     "node_modules/@ember-data/model": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-5.3.9.tgz",
-      "integrity": "sha512-cYNkxiAvTCO67FMuPDagvvs/iYr68l9Dg40qB7em1Jhy0QmwpajvxkyEaj6q/fOrGaH69KmzHJhOvu4eKGTz8Q==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-5.3.13.tgz",
+      "integrity": "sha512-zz7KSxCWmqFkM5pOJPmJbSLii/IpYOZ2EFKcw5PApW/pDtd/bw0PQsj1vBy+iAzI3go2maYZip730s4t1VTjhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7",
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "inflection": "~3.0.0"
+        "inflection": "~3.0.2"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/graph": "5.3.9",
-        "@ember-data/json-api": "5.3.9",
-        "@ember-data/legacy-compat": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@ember-data/tracking": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/graph": "5.3.13",
+        "@ember-data/json-api": "5.3.13",
+        "@ember-data/legacy-compat": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@ember-data/tracking": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "@ember-data/graph": {
@@ -1920,43 +1933,47 @@
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.2.tgz",
       "integrity": "sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@ember-data/request": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/request/-/request-5.3.9.tgz",
-      "integrity": "sha512-odTe3B7eLt9HsrExkeIr6PwLP+uiS4chqu4JVxqDnCk8KpnOnbKgVnQQbIEFx8jTuv0y1vS+Jc9o6vynSV5YjQ==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/request/-/request-5.3.13.tgz",
+      "integrity": "sha512-BtneB/msAnvq1lgpthQ9avbuLkOP2i9BNwGLvJGmiPQAplM/ny1M9vS26UEmdwn0F3+uC36IgcJbXplO/rDq3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ember/test-waiters": "^3.1.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember/test-waiters": "^3.1.0 || ^4.0.0",
+        "@warp-drive/core-types": "0.0.3"
       }
     },
     "node_modules/@ember-data/request-utils": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/request-utils/-/request-utils-5.3.9.tgz",
-      "integrity": "sha512-4qZNh2ZbmKBSwE2jUHYl8QNlfqU9f4ww+z3HO70aJLtFjmnwWrsENi1N9st0mWEpR201UlEiFvF3gmyjv2Hn4g==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/request-utils/-/request-utils-5.3.13.tgz",
+      "integrity": "sha512-a6JLegqJ/GwLkOXU77RE38E8hkhsvFjpZFQUIVMdFuINz7sy1lhC8koatxDzTU3glAYH1zoA12UZ8AJU0wXoKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
         "@ember/string": "^3.1.1 || ^4.0.0",
-        "@warp-drive/core-types": "0.0.0-beta.12",
-        "ember-inflector": "^4.0.2 || ^5.0.0"
+        "@warp-drive/core-types": "0.0.3",
+        "ember-inflector": "^4.0.2 || ^5.0.0 || ^6.0.0",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "@ember/string": {
@@ -1973,62 +1990,67 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "node_modules/@ember-data/serializer": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-5.3.9.tgz",
-      "integrity": "sha512-LzXh1972xs5kTNysql8ZptD1rI+WrZAskFdj9+8a+ON0TmxDznaS4PQjCi3Rw3+qF/h5qYZm105Yd8Z/AlzH5w==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-5.3.13.tgz",
+      "integrity": "sha512-ZARVjMM66YVEooDMzvMRrcdZQaXlQDNKVzERgPcluiLZGhxalFX5wXLyNV7vTV4OShZZdrZSlGrpSk/3uyGGBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ember/edition-utils": "1.2.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7",
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/legacy-compat": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/legacy-compat": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-5.3.9.tgz",
-      "integrity": "sha512-3G24GtpgRKGlvTbF6Q6Uz/YQqxFrSfgvXpdqbSjMRu5UDd/EI7qkB+MOgD1rV6EBJ2xpic5+6a0q154lTL0dUg==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-5.3.13.tgz",
+      "integrity": "sha512-5Mx4k/p0z+PN5NtY+CepXHNerGmtQpHyDr80PzUw65Mtmftdcns0LJiSMxbuvObt3fXH8PA54cSBxwpS9G3y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember-data/request": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/tracking": "5.3.9",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@ember-data/request": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/tracking": "5.3.13",
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember-data/tracking": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-5.3.9.tgz",
-      "integrity": "sha512-YRhf4AqG8SUP5t0GgGmqq6iAGwtNqtf2HtW/GQ4V8WO3jDtYyPVB+li78hdFxkkc3zxLtMiXoLVhPjtloyR8Eg==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-5.3.13.tgz",
+      "integrity": "sha512-9qD038n0MRXq+wfsVtPo0feZ7iq3yrvofXadfQhJgVQU5ieHyFaSsM8cfPRsGXeBk5nEdaUmB471TqqCPtjeag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@warp-drive/core-types": "0.0.0-beta.12",
-        "ember-source": ">= 3.28.12"
+        "@warp-drive/core-types": "0.0.3",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ember/edition-utils": {
@@ -2495,13 +2517,14 @@
       }
     },
     "node_modules/@embroider/macros": {
-      "version": "1.16.10",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.10.tgz",
-      "integrity": "sha512-G0vCsKgNCX0PMmuVNsTLG7IYXz8VkekQMK4Kcllzqpwb7ivFRDwVx2bD4QSvZ9LCTd4eWQ654RsCqVbW5aviww==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.18.0.tgz",
+      "integrity": "sha512-KanP80XxNK4bmQ1HKTcUjy/cdCt9n7knPMLK1vzHdOFymACHo+GbhgUjXjYdOCuBTv+ZwcjL2P2XDmBcYS9r8g==",
+      "license": "MIT",
       "dependencies": {
-        "@embroider/shared-internals": "2.8.1",
+        "@embroider/shared-internals": "3.0.0",
         "assert-never": "^1.2.1",
-        "babel-import-util": "^2.0.0",
+        "babel-import-util": "^3.0.1",
         "ember-cli-babel": "^7.26.6",
         "find-up": "^5.0.0",
         "lodash": "^4.17.21",
@@ -2546,12 +2569,116 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-3.0.0.tgz",
+      "integrity": "sha512-5J5ipUMCAinQS38WW7wedruq5Z4VnHvNo+ZgOduw0PtI9w0CQWx7/HE+98PBDW8jclikeF+aHwF317vc1hwuzg==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-import-util": "^3.0.1",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "is-subdir": "^1.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "pkg-entry-points": "^1.1.0",
+        "resolve-package-path": "^4.0.1",
+        "resolve.exports": "^2.0.2",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@embroider/macros/node_modules/@types/fs-extra": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
       "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/babel-import-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.1.tgz",
+      "integrity": "sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/macros/node_modules/babel-plugin-module-resolver": {
@@ -5477,26 +5604,27 @@
       "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="
     },
     "node_modules/@warp-drive/build-config": {
-      "version": "0.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@warp-drive/build-config/-/build-config-0.0.0-beta.7.tgz",
-      "integrity": "sha512-EHBWwNTv62OA9C24VEEeU04A2JNkMYiJjkA/cXnuQeM0/HSYyki4vtHtCjFXGG397KUpS0bkFBzzfXivHof9yA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@warp-drive/build-config/-/build-config-0.0.3.tgz",
+      "integrity": "sha512-cvaZE2tF73o+DvXkKmu7WU65tDffAZKQgRh3HWnVWksWs7B4rn86zGg3uUh6edKnpZ76o7xQ0cBaqdQkoDJ5Ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/addon-shim": "^1.8.9",
-        "@embroider/macros": "^1.16.6",
+        "@embroider/addon-shim": "^1.9.0",
+        "@embroider/macros": "^1.16.12",
         "babel-import-util": "^2.1.1",
-        "broccoli-funnel": "^3.0.8",
-        "semver": "^7.6.3"
+        "semver": "^7.7.1"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       }
     },
     "node_modules/@warp-drive/build-config/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5505,16 +5633,17 @@
       }
     },
     "node_modules/@warp-drive/core-types": {
-      "version": "0.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@warp-drive/core-types/-/core-types-0.0.0-beta.12.tgz",
-      "integrity": "sha512-OLHKHhC2oCOyTBVUNHDNppp9vVBK3FSxDBx7jGWS5nBF13/F8O6IGipQwUsiLa3Pu3Ag8x4YOL0shnDjRIFueg==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@warp-drive/core-types/-/core-types-0.0.3.tgz",
+      "integrity": "sha512-8dJY4CIekQSndEL5ORvWoYOLBL1u7YREth3jPmZQTpMGmUFc23f1WzgBKNesXV1cXGl7AUum+wvavOtvyUFzzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -9403,6 +9532,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/code-error-fragment": {
+      "version": "0.0.230",
+      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
+      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -12724,6 +12863,7 @@
       "resolved": "https://registry.npmjs.org/ember-cli-test-info/-/ember-cli-test-info-1.0.0.tgz",
       "integrity": "sha512-dEVTIpmUfCzweC97NGf6p7L6XKBwV2GmSM4elmzKvkttEp5P7AvGA9uGyN4GqFq+RwhW+2b0I2qlX00w+skm+A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "ember-cli-string-utils": "^1.0.0"
       }
@@ -14143,33 +14283,35 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-5.3.9.tgz",
-      "integrity": "sha512-fUhvmq3piYapfSFlpFpuQrkGn9SPRzPNj9xfHtFhyUq7UrPSXvjbhsihg+vw46VLxNqlTUwVtU3kLjGuJU6O9Q==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-5.3.13.tgz",
+      "integrity": "sha512-Jke7Bx45GDrq72Co/eHtOb6wfeyMUAmxKaRhibVrEQqy9jXwFWPKIcPwF20v7oWkO/bBEK2BDpM5enLDiVEmsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ember-data/adapter": "5.3.9",
-        "@ember-data/debug": "5.3.9",
-        "@ember-data/graph": "5.3.9",
-        "@ember-data/json-api": "5.3.9",
-        "@ember-data/legacy-compat": "5.3.9",
-        "@ember-data/model": "5.3.9",
-        "@ember-data/request": "5.3.9",
-        "@ember-data/request-utils": "5.3.9",
-        "@ember-data/serializer": "5.3.9",
-        "@ember-data/store": "5.3.9",
-        "@ember-data/tracking": "5.3.9",
+        "@ember-data/adapter": "5.3.13",
+        "@ember-data/debug": "5.3.13",
+        "@ember-data/graph": "5.3.13",
+        "@ember-data/json-api": "5.3.13",
+        "@ember-data/legacy-compat": "5.3.13",
+        "@ember-data/model": "5.3.13",
+        "@ember-data/request": "5.3.13",
+        "@ember-data/request-utils": "5.3.13",
+        "@ember-data/serializer": "5.3.13",
+        "@ember-data/store": "5.3.13",
+        "@ember-data/tracking": "5.3.13",
         "@ember/edition-utils": "^1.2.0",
-        "@embroider/macros": "^1.16.6",
-        "@warp-drive/build-config": "0.0.0-beta.7",
-        "@warp-drive/core-types": "0.0.0-beta.12"
+        "@embroider/macros": "^1.16.12",
+        "@warp-drive/build-config": "0.0.3",
+        "@warp-drive/core-types": "0.0.3"
       },
       "engines": {
-        "node": ">= 18.20.4"
+        "node": ">= 18.20.8"
       },
       "peerDependencies": {
-        "@ember/test-helpers": "^3.3.0 || ^4.0.4",
-        "@ember/test-waiters": "^3.1.0",
+        "@ember/test-helpers": "^3.3.0 || ^4.0.4 || ^5.1.0",
+        "@ember/test-waiters": "^3.1.0 || ^4.0.0",
+        "ember-source": "3.28.12 || ^4.0.4 || ^5.0.0 || ^6.0.0",
         "qunit": "^2.18.0"
       },
       "peerDependenciesMeta": {
@@ -21011,10 +21153,11 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
-      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }
@@ -21473,6 +21616,13 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -23128,6 +23278,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json-to-ast": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
+      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-error-fragment": "0.0.230",
+        "grapheme-splitter": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -27208,6 +27372,15 @@
       "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated",
       "dev": true
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/responselike": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-cli-version-checker": "^5.1.2",
     "ember-concurrency": "^4.0.2",
     "ember-modifier": "^4.1.0",
-    "ember-truth-helpers": "^3.0.0 || ^4.0.0",
+    "ember-truth-helpers": "^4.0.0",
     "forking-store": "^2.0.0",
     "rdflib": "^2.2.19",
     "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
-    "ember-data": "~5.3.0",
+    "ember-data": "~5.3.13",
     "ember-load-initializers": "^2.1.2",
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-page-title": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.15.0 || ^3.7.0",
+    "@appuniversum/ember-appuniversum": "^3.7.0",
     "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "ember-source": ">= 4.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-version-checker": "^5.1.2",
-    "ember-concurrency": "^2.3.2 || ^3.0.0 || ^4.0.2",
+    "ember-concurrency": "^4.0.2",
     "ember-modifier": "^4.1.0",
     "ember-truth-helpers": "^3.0.0 || ^4.0.0",
     "forking-store": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^3.7.0",
-    "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
+    "ember-data": "^5.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "ember-source": ">= 4.0.0"
   },


### PR DESCRIPTION
Since we're going to release a major we can remove support for older dependency versions.

**New requirements:**
- Appuniversum v3
- ember-data v5
- ember-truth-helpers v4
- ember-concurrency v4
