### PR TITLE
Convert `@lblod/submission-form-helpers` to a peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@babel/core": "7.26.0",
         "@embroider/macros": "^1.13.5",
-        "@lblod/submission-form-helpers": "^3.0.0",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",
@@ -35,6 +34,7 @@
         "@embroider/test-setup": "^4.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@lblod/submission-form-helpers": "^3.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.2.2",
         "ember-basic-dropdown": "^8.3.0",
@@ -81,6 +81,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^3.7.0",
+        "@lblod/submission-form-helpers": "^3.0.0",
         "ember-data": "^5.0.0",
         "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "ember-source": ">= 4.0.0"
@@ -4692,6 +4693,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-3.0.0.tgz",
       "integrity": "sha512-EXvGpjoLoNHh0IAvGzynciB48v3YH3eqExDuiKzWgrLc0UkcSHDFZAQLf3XnH1LH9793PLnIMaC2CE9Mi0isYQ==",
+      "dev": true,
       "dependencies": {
         "iban": "0.0.14",
         "libphonenumber-js": "^1.9.6",
@@ -21671,7 +21673,8 @@
     "node_modules/iban": {
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/iban/-/iban-0.0.14.tgz",
-      "integrity": "sha512-+rocNKk+Ga9m8Lr9fTMWd+87JnsBrucm0ZsIx5ROOarZlaDLmd+FKdbtvb0XyoBw9GAFOYG2GuLqoNB16d+p3w=="
+      "integrity": "sha512-+rocNKk+Ga9m8Lr9fTMWd+87JnsBrucm0ZsIx5ROOarZlaDLmd+FKdbtvb0XyoBw9GAFOYG2GuLqoNB16d+p3w==",
+      "dev": true
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -23096,7 +23099,8 @@
     "node_modules/libphonenumber-js": {
       "version": "1.11.17",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.17.tgz",
-      "integrity": "sha512-Jr6v8thd5qRlOlc6CslSTzGzzQW03uiscab7KHQZX1Dfo4R6n6FDhZ0Hri6/X7edLIDv9gl4VMZXhxTjLnl0VQ=="
+      "integrity": "sha512-Jr6v8thd5qRlOlc6CslSTzGzzQW03uiscab7KHQZX1Dfo4R6n6FDhZ0Hri6/X7edLIDv9gl4VMZXhxTjLnl0VQ==",
+      "dev": true
     },
     "node_modules/line-column": {
       "version": "1.0.2",
@@ -23995,6 +23999,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -30396,6 +30401,7 @@
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
       "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@babel/core": "7.26.0",
     "@embroider/macros": "^1.13.5",
-    "@lblod/submission-form-helpers": "^3.0.0",
     "client-zip": "^2.4.4",
     "clipboardy": "^4.0.0",
     "ember-auto-import": "^2.8.1",
@@ -47,6 +46,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^3.7.0",
+    "@lblod/submission-form-helpers": "^3.0.0",
     "ember-data": "^5.0.0",
     "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "ember-source": ">= 4.0.0"
@@ -61,6 +61,7 @@
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@lblod/submission-form-helpers": "^3.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.2.2",
     "ember-basic-dropdown": "^8.3.0",


### PR DESCRIPTION
Apps can't realistically use this addon without also using the form-helpers package themselves, so this makes that dependency clearer and easier to manage from the app's package.json.