### PR TITLE
Remove deprecated code

### DIFF
--- a/addon/components/form-section.hbs
+++ b/addon/components/form-section.hbs
@@ -74,16 +74,6 @@
                 @show={{@show}}
               />
             {{/let}}
-
-            {{! template-lint-disable simple-unless}}
-            {{#unless
-              (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))
-            }}
-              {{#if field.help}}
-                {{! template-lint-disable no-triple-curlies}}
-                <AuHelpText>{{{field.help}}}</AuHelpText>
-              {{/if}}
-            {{/unless}}
           </div>
         {{/if}}
       {{/if}}

--- a/addon/components/private/help-text.hbs
+++ b/addon/components/private/help-text.hbs
@@ -1,8 +1,6 @@
-{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-  {{#if @field.help}}
-    {{! template-lint-disable no-triple-curlies}}
-    <AuHelpText
-      class="au-u-margin-top-none au-u-margin-bottom-tiny"
-    >{{{@field.help}}}</AuHelpText>
-  {{/if}}
+{{#if @field.help}}
+  {{! template-lint-disable no-triple-curlies}}
+  <AuHelpText
+    class="au-u-margin-top-none au-u-margin-bottom-tiny"
+  >{{{@field.help}}}</AuHelpText>
 {{/if}}

--- a/addon/components/rdf-input-fields/case-number.hbs
+++ b/addon/components/rdf-input-fields/case-number.hbs
@@ -1,9 +1,6 @@
 <AuLabel
   for={{this.id}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >{{@field.label}}</AuLabel>
 <this.HelpText @field={{@field}} />
 {{#if this.showAlert}}

--- a/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-select-checkboxes.hbs
@@ -1,10 +1,4 @@
-<AuFieldset
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "sf-u-gap-initial"
-  }}
-  as |f|
->
+<AuFieldset class={{if @field.help "sf-u-gap-initial"}} as |f|>
   <f.legend
     @required={{this.isRequired}}
     @requiredLabel={{this.requiredLabel}}

--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
@@ -3,10 +3,7 @@
   @warnings={{this.hasWarnings}}
   @required={{this.isRequired}}
   for={{this.inputId}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>

--- a/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-radio-buttons.hbs
@@ -1,10 +1,4 @@
-<AuFieldset
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "sf-u-gap-initial"
-  }}
-  as |f|
->
+<AuFieldset class={{if @field.help "sf-u-gap-initial"}} as |f|>
   <f.legend
     @required={{this.isRequired}}
     @error={{this.hasErrors}}

--- a/addon/components/rdf-input-fields/concept-scheme-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-selector.hbs
@@ -4,10 +4,7 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
   </AuLabel>

--- a/addon/components/rdf-input-fields/currency-input.hbs
+++ b/addon/components/rdf-input-fields/currency-input.hbs
@@ -4,10 +4,7 @@
     @warning={{this.hasWarnings}}
     @required={{this.isRequired}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
   </AuLabel>

--- a/addon/components/rdf-input-fields/date-picker.hbs
+++ b/addon/components/rdf-input-fields/date-picker.hbs
@@ -3,26 +3,21 @@
   @required={{this.isRequired}}
   @warning={{this.hasWarnings}}
   for={{this.inputId}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>
 
 <this.HelpText @field={{@field}} />
 
-{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-  {{#unless @show}}
-    <AuHelpText
-      @error={{this.hasErrors}}
-      class="au-u-margin-top-none au-u-margin-bottom-tiny"
-    >
-      Datum formaat: DD-MM-JJJJ
-    </AuHelpText>
-  {{/unless}}
-{{/if}}
+{{#unless @show}}
+  <AuHelpText
+    @error={{this.hasErrors}}
+    class="au-u-margin-top-none au-u-margin-bottom-tiny"
+  >
+    Datum formaat: DD-MM-JJJJ
+  </AuHelpText>
+{{/unless}}
 
 <div class="au-o-grid au-o-grid--flush">
   <div class="au-o-grid__item au-u-3-4">
@@ -37,15 +32,6 @@
     />
   </div>
 </div>
-
-{{!template-lint-disable simple-unless}}
-{{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-  {{#unless @show}}
-    <AuHelpText @error={{this.hasErrors}}>
-      Datum formaat: DD-MM-JJJJ
-    </AuHelpText>
-  {{/unless}}
-{{/unless}}
 
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>

--- a/addon/components/rdf-input-fields/date-range.hbs
+++ b/addon/components/rdf-input-fields/date-range.hbs
@@ -1,8 +1,5 @@
 <AuLabel
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >{{@field.label}}</AuLabel>
 
 <this.HelpText @field={{@field}} />

--- a/addon/components/rdf-input-fields/date-time.hbs
+++ b/addon/components/rdf-input-fields/date-time.hbs
@@ -3,26 +3,21 @@
   @required={{this.isRequired}}
   @warning={{this.hasWarnings}}
   for={{this.inputId}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>
 
 <this.HelpText @field={{@field}} />
 
-{{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-  {{#unless @show}}
-    <AuHelpText
-      @error={{this.hasErrors}}
-      class="au-u-margin-top-none au-u-margin-bottom-tiny"
-    >
-      Datum formaat: DD-MM-JJJJ
-    </AuHelpText>
-  {{/unless}}
-{{/if}}
+{{#unless @show}}
+  <AuHelpText
+    @error={{this.hasErrors}}
+    class="au-u-margin-top-none au-u-margin-bottom-tiny"
+  >
+    Datum formaat: DD-MM-JJJJ
+  </AuHelpText>
+{{/unless}}
 
 <div class="au-o-grid au-o-grid--flush">
   <div class="au-o-grid__item au-u-3-4">
@@ -36,14 +31,6 @@
       {{on "blur" (fn (mut this.hasBeenFocused) true)}}
     />
 
-    {{!template-lint-disable simple-unless}}
-    {{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-      {{#unless @show}}
-        <AuHelpText @error={{this.hasErrors}}>
-          Datum formaat: DD-MM-JJJJ
-        </AuHelpText>
-      {{/unless}}
-    {{/unless}}
     {{#each this.errors as |error|}}
       <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
     {{/each}}

--- a/addon/components/rdf-input-fields/date.hbs
+++ b/addon/components/rdf-input-fields/date.hbs
@@ -4,25 +4,20 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
   </AuLabel>
   <this.HelpText @field={{@field}} />
 
-  {{#if (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-    {{#unless @show}}
-      <AuHelpText
-        @error={{this.hasErrors}}
-        class="au-u-margin-top-none au-u-margin-bottom-tiny"
-      >
-        Datum formaat: DD-MM-JJJJ
-      </AuHelpText>
-    {{/unless}}
-  {{/if}}
+  {{#unless @show}}
+    <AuHelpText
+      @error={{this.hasErrors}}
+      class="au-u-margin-top-none au-u-margin-bottom-tiny"
+    >
+      Datum formaat: DD-MM-JJJJ
+    </AuHelpText>
+  {{/unless}}
 {{/unless}}
 <div class={{unless @inTable "au-o-grid au-o-grid--flush"}}>
   <div class={{unless @inTable "au-o-grid__item au-u-3-4"}}>
@@ -39,14 +34,6 @@
   </div>
 </div>
 
-{{!template-lint-disable simple-unless}}
-{{#unless (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))}}
-  {{#if (not (or @show @inTable))}}
-    <AuHelpText @error={{this.hasErrors}}>
-      Datum formaat: DD-MM-JJJJ
-    </AuHelpText>
-  {{/if}}
-{{/unless}}
 {{#each this.errors as |error|}}
   <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
 {{/each}}

--- a/addon/components/rdf-input-fields/files.hbs
+++ b/addon/components/rdf-input-fields/files.hbs
@@ -69,14 +69,5 @@
     {{/each}}
   {{/unless}}
 {{else}}
-  {{! TODO: Remove this check once we drop Appuniversum v2 support }}
-  {{#if
-    (macroCondition
-      (macroDependencySatisfies "@appuniversum/ember-appuniversum" "^3.2.0")
-    )
-  }}
-    <AuLoader @centered={{false}} @hideMessage={{true}}>Bestanden aan het laden</AuLoader>
-  {{else}}
-    <AuLoader @padding="small" />
-  {{/if}}
+  <AuLoader @centered={{false}} @hideMessage={{true}}>Bestanden aan het laden</AuLoader>
 {{/if}}

--- a/addon/components/rdf-input-fields/input.hbs
+++ b/addon/components/rdf-input-fields/input.hbs
@@ -4,10 +4,7 @@
     @warning={{this.hasWarnings}}
     @required={{this.isRequired}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
     {{#unless @show}}

--- a/addon/components/rdf-input-fields/numerical-input.hbs
+++ b/addon/components/rdf-input-fields/numerical-input.hbs
@@ -4,10 +4,7 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
   </AuLabel>

--- a/addon/components/rdf-input-fields/remote-urls/edit.hbs
+++ b/addon/components/rdf-input-fields/remote-urls/edit.hbs
@@ -4,10 +4,7 @@
   @requiredLabel={{@requiredLabel}}
   @warning={{this.hasWarnings}}
   for={{this.inputFor}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>

--- a/addon/components/rdf-input-fields/search.hbs
+++ b/addon/components/rdf-input-fields/search.hbs
@@ -1,9 +1,6 @@
 <AuLabel
   for={{this.inputId}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>

--- a/addon/components/rdf-input-fields/text-area.hbs
+++ b/addon/components/rdf-input-fields/text-area.hbs
@@ -4,10 +4,7 @@
     @required={{this.isRequired}}
     @warning={{this.hasWarnings}}
     for={{this.inputId}}
-    class={{if
-      (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-      "au-u-margin-bottom-none"
-    }}
+    class={{if @field.help "au-u-margin-bottom-none"}}
   >
     {{@field.label}}
   </AuLabel>
@@ -31,7 +28,10 @@
 />
 {{#unless @show}}
   {{#if this.maxLength}}
-    <AuPill @skin={{unless this.hasRemainingCharacters "error"}} class="au-u-margin-top-tiny">Resterende karakters: {{this.remainingCharacters}}</AuPill>
+    <AuPill
+      @skin={{unless this.hasRemainingCharacters "error"}}
+      class="au-u-margin-top-tiny"
+    >Resterende karakters: {{this.remainingCharacters}}</AuPill>
   {{/if}}
 {{/unless}}
 {{#each this.errors as |error|}}

--- a/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
+++ b/addon/components/rdf-input-fields/vlabel-opcentiem.hbs
@@ -1,9 +1,6 @@
 <AuLabel
   @required={{this.isRequired}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>

--- a/addon/components/search-panel-fields/search/edit.hbs
+++ b/addon/components/search-panel-fields/search/edit.hbs
@@ -1,9 +1,6 @@
 <AuLabel
   for={{this.inputId}}
-  class={{if
-    (and (macroGetOwnConfig "helpTextBelowLabel") @field.help)
-    "au-u-margin-bottom-none"
-  }}
+  class={{if @field.help "au-u-margin-bottom-none"}}
 >
   {{@field.label}}
 </AuLabel>

--- a/addon/components/submission-form.hbs
+++ b/addon/components/submission-form.hbs
@@ -23,16 +23,6 @@
               @forceShowErrors={{@forceShowErrors}}
               @show={{@show}}
             />
-
-            {{! template-lint-disable simple-unless}}
-            {{#unless
-              (macroCondition (macroGetOwnConfig "helpTextBelowLabel"))
-            }}
-              {{#unless @show}}
-                {{! template-lint-disable no-triple-curlies}}
-                <AuHelpText>{{{field.help}}}</AuHelpText>
-              {{/unless}}
-            {{/unless}}
           {{/let}}
         </li>
       {{/if}}

--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -1,5 +1,4 @@
-import { assert, deprecate } from '@ember/debug';
-import { getOwnConfig, macroCondition } from '@embroider/macros';
+import { assert } from '@ember/debug';
 
 // Basic fields
 import AlertComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/alert';
@@ -38,28 +37,6 @@ const CUSTOM_EDIT_COMPONENTS = new Map();
 const CUSTOM_SHOW_COMPONENTS = new Map();
 
 export function registerFormFields(customFields) {
-  if (macroCondition(!getOwnConfig().helpTextBelowLabel)) {
-    deprecate(
-      `\
-The way the help text of a form field is displayed is going to change. Fields will become responsible for displaying their help text instead of it being added below the field automatically.
-This makes the setup more flexible but it does mean custom fields need to do some manual changes.
-
-More information in the migration guide: https://github.com/lblod/ember-submission-form-fields/pull/202
-
-`,
-      false,
-      {
-        id: '@lblod/ember-submission-form-fields.help-text-position',
-        until: '3.0.0',
-        for: '@lblod/ember-submission-form-fields',
-        since: {
-          available: '2.26.0',
-          enabled: '2.26.0',
-        },
-      },
-    );
-  }
-
   registerComponentsForDisplayType(customFields, false);
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,14 +14,6 @@ const webpackConfig = {
 
 module.exports = function (defaults) {
   const customBuildConfig = {
-    // TODO: Remove this once we release v3
-    '@lblod/ember-submission-form-fields': {
-      helpTextBelowLabel: true,
-    },
-    '@appuniversum/ember-appuniversum': {
-      dutchDatePickerLocalization: true,
-      disableWormholeElement: true,
-    },
     autoImport: {
       webpack: webpackConfig,
     },

--- a/index.js
+++ b/index.js
@@ -8,19 +8,5 @@ module.exports = {
         require.resolve('ember-concurrency/async-arrow-task-transform'),
       ],
     },
-    '@embroider/macros': {
-      setOwnConfig: {
-        helpTextBelowLabel: false,
-      },
-    },
-  },
-
-  included: function (app) {
-    this._super.included.apply(this, arguments);
-    let addonOptions = app.options[this.name];
-    if (addonOptions) {
-      let ownConfig = this.options['@embroider/macros'].setOwnConfig;
-      Object.assign(ownConfig, addonOptions);
-    }
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.0",
-        "@embroider/macros": "^1.13.5",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@babel/core": "7.26.0",
-    "@embroider/macros": "^1.13.5",
     "client-zip": "^2.4.4",
     "clipboardy": "^4.0.0",
     "ember-auto-import": "^2.8.1",


### PR DESCRIPTION
This removes the conditional code that was introduced in #202. `helpTextBelowLabel` is no longer an option, and it will be forced to its `true` state.