### PR TITLE
Make it possible to override the built-in fields

### DIFF
--- a/addon/utils/display-type.js
+++ b/addon/utils/display-type.js
@@ -58,12 +58,6 @@ export function registerComponentsForDisplayType(
     );
 
     assert(
-      `Registering a component for the '${displayType}' display type isn't allowed since a built-in component already handles it.`,
-      !BUILT_IN_SHOW_COMPONENTS.has(displayType) &&
-        !BUILT_IN_EDIT_COMPONENTS.has(displayType),
-    );
-
-    assert(
       `A show or edit component is required when registering custom fields`,
       Boolean(edit) || Boolean(show),
     );
@@ -106,19 +100,19 @@ export function getComponentForDisplayType(displayType, show) {
   let component;
 
   if (show) {
-    component = BUILT_IN_SHOW_COMPONENTS.get(displayType);
-  }
-
-  if (!component) {
-    component = BUILT_IN_EDIT_COMPONENTS.get(displayType);
-  }
-
-  if (show && !component) {
     component = CUSTOM_SHOW_COMPONENTS.get(displayType);
   }
 
   if (!component) {
     component = CUSTOM_EDIT_COMPONENTS.get(displayType);
+  }
+
+  if (show && !component) {
+    component = BUILT_IN_SHOW_COMPONENTS.get(displayType);
+  }
+
+  if (!component) {
+    component = BUILT_IN_EDIT_COMPONENTS.get(displayType);
   }
 
   assert(

--- a/tests/unit/utils/display-type-test.js
+++ b/tests/unit/utils/display-type-test.js
@@ -51,6 +51,50 @@ module('Unit | Utility | display-type', function () {
       assert.strictEqual(FieldComponent, ShowComponent);
     });
 
+    test('it prioritizes custom components over the built-in ones for a specific display type', function (assert) {
+      registerComponentsForDisplayType([
+        {
+          displayType: TEST_DISPLAY_TYPE,
+          edit: EditComponent,
+          show: ShowComponent,
+        },
+      ]);
+
+      const CustomEditComponent = setComponentTemplate(
+        hbs`custom edit`,
+        templateOnlyComponent(),
+      );
+      const CustomShowComponent = setComponentTemplate(
+        hbs`custom show`,
+        templateOnlyComponent(),
+      );
+
+      registerComponentsForDisplayType(
+        [
+          {
+            displayType: TEST_DISPLAY_TYPE,
+            edit: CustomEditComponent,
+            show: CustomShowComponent,
+          },
+        ],
+        false,
+      );
+
+      let FieldComponent = getComponentForDisplayType(TEST_DISPLAY_TYPE);
+      assert.strictEqual(
+        FieldComponent,
+        CustomEditComponent,
+        'it returns the custom edit component',
+      );
+
+      FieldComponent = getComponentForDisplayType(
+        TEST_DISPLAY_TYPE,
+        true,
+        'it returns the custom show component',
+      );
+      assert.strictEqual(FieldComponent, CustomShowComponent);
+    });
+
     test('it throws an error if a display type has no corresponding component', function (assert) {
       assert.throws(() => {
         let FieldComponent = getComponentForDisplayType(

--- a/tests/unit/utils/register-form-fields-test.js
+++ b/tests/unit/utils/register-form-fields-test.js
@@ -144,7 +144,7 @@ module('Unit | Utility | registerFormFields', function (hooks) {
     }, /`displayType` is required when registering a form field/);
   });
 
-  test('it throws an error when trying to override a built-in display type', function (assert) {
+  test('it can override a built-in display type', function (assert) {
     registerComponentsForDisplayType([
       {
         displayType: 'http://lblod.data.gift/display-types/built-in',
@@ -157,14 +157,19 @@ module('Unit | Utility | registerFormFields', function (hooks) {
       templateOnlyComponent(),
     );
 
-    assert.throws(() => {
+    try {
       registerFormFields([
         {
           displayType: 'http://lblod.data.gift/display-types/built-in',
           edit: ComponentOverride,
         },
       ]);
-    }, /Registering a component for the 'http:\/\/lblod\.data\.gift\/display-types\/built-in' display type isn't allowed since a built-in component already handles it./);
+      assert.step('nothing went wrong');
+    } catch (error) {
+      assert.step('something went wrong');
+    }
+
+    assert.verifySteps(['nothing went wrong']);
   });
 
   test('it throws an error if no components are provided', function (assert) {


### PR DESCRIPTION
This can be handy to extend or replace one of the built-in fields without having to use a different display type name in the form configs.