### PR TITLE
Resolve the `PowerSelectMultiple` deprecation

### DIFF
--- a/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
+++ b/addon/components/rdf-input-fields/concept-scheme-multi-selector.hbs
@@ -11,24 +11,49 @@
 <this.HelpText @field={{@field}} />
 
 <div class={{if this.hasErrors "ember-power-select--error"}}>
-  <PowerSelectMultiple
-    @triggerId={{this.inputId}}
-    @search={{perform this.search}}
-    @searchField="label"
-    @searchPlaceholder="Typ hier om te zoeken..."
-    @searchEnabled={{this.searchEnabled}}
-    @selected={{this.selected}}
-    @options={{this.subset}}
-    @onClose={{fn (mut this.hasBeenFocused) true}}
-    @onChange={{this.updateSelection}}
-    @allowClear={{true}}
-    @loadingMessage="Aan het laden..."
-    @noMatchesMessage="Geen resultaten gevonden"
-    @disabled={{@show}}
-    as |concept|
-  >
-    {{concept.label}}
-  </PowerSelectMultiple>
+  {{#if
+    (macroCondition (macroDependencySatisfies "ember-power-select" "^8.11.0"))
+  }}
+    <PowerSelect
+      @triggerId={{this.inputId}}
+      @search={{perform this.search}}
+      @searchField="label"
+      @searchPlaceholder="Typ hier om te zoeken..."
+      @searchEnabled={{this.searchEnabled}}
+      @selected={{this.selected}}
+      @options={{this.subset}}
+      @onClose={{fn (mut this.hasBeenFocused) true}}
+      @onChange={{this.updateSelection}}
+      @allowClear={{true}}
+      @loadingMessage="Aan het laden..."
+      @noMatchesMessage="Geen resultaten gevonden"
+      @disabled={{@show}}
+      @multiple={{true}}
+      as |concept|
+    >
+      {{concept.label}}
+    </PowerSelect>
+  {{else}}
+    {{!TODO: Remove this once we drop support for ember-power-select < v8}}
+    <PowerSelectMultiple
+      @triggerId={{this.inputId}}
+      @search={{perform this.search}}
+      @searchField="label"
+      @searchPlaceholder="Typ hier om te zoeken..."
+      @searchEnabled={{this.searchEnabled}}
+      @selected={{this.selected}}
+      @options={{this.subset}}
+      @onClose={{fn (mut this.hasBeenFocused) true}}
+      @onChange={{this.updateSelection}}
+      @allowClear={{true}}
+      @loadingMessage="Aan het laden..."
+      @noMatchesMessage="Geen resultaten gevonden"
+      @disabled={{@show}}
+      as |concept|
+    >
+      {{concept.label}}
+    </PowerSelectMultiple>
+  {{/if}}
 </div>
 
 {{#each this.errors as |error|}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "7.26.0",
+        "@embroider/macros": "^1.20.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@babel/core": "7.26.0",
+    "@embroider/macros": "^1.20.2",
     "client-zip": "^2.4.4",
     "clipboardy": "^4.0.0",
     "ember-auto-import": "^2.8.1",


### PR DESCRIPTION
We now use the new `@multiple` argument if the power-select version is new enough.