### PR TITLE
[DL-7363] Fix downloadAsZip to work with files containing special characters

### DIFF
--- a/addon/components/rdf-input-fields/files.js
+++ b/addon/components/rdf-input-fields/files.js
@@ -190,7 +190,7 @@ export default class RdfInputFieldsFilesComponent extends InputFieldComponent {
           );
         }
 
-        return response;
+        return { input: response, name: file.record.filename };
       });
     });
 


### PR DESCRIPTION
[DL-7363]

Fix to allow files containing special characters in their titels (E.g. ^) to be downloaded as a zip.

TO TEST:
see https://github.com/lblod/frontend-toezicht-abb/pull/82 and https://github.com/lblod/frontend-worship-decisions/pull/47